### PR TITLE
add LCD brightness control

### DIFF
--- a/lcd.c
+++ b/lcd.c
@@ -32,6 +32,11 @@ void lcd_refresh(void)
 	LCD_1IN14_V2_Display(&img[0]);
 }
 
+void lcd_brightness(int brightness)
+{
+	DEV_SET_PWM((uint8_t) brightness);
+}
+
 void lcd_info(void)
 {
 	Paint_DrawString_EN(25, 40, "Waiting for", &Font24, RED, BLACK);

--- a/lcd.h
+++ b/lcd.h
@@ -11,8 +11,11 @@
 #include "DEV_Config.h"
 #include "GUI_Paint.h"
 
+#define DEFAULT_BRIGHTNESS 90
+
 extern void lcd_init(void);
 extern void lcd_refresh(void);
+extern void lcd_brightness(int);
 extern void lcd_banner(void), lcd_info(void), lcd_running(void);
 
 #endif

--- a/lcd/Config/DEV_Config.c
+++ b/lcd/Config/DEV_Config.c
@@ -149,7 +149,6 @@ UBYTE DEV_Module_Init(void)
     // GPIO Config
     DEV_GPIO_Init();
 
-#if 0	// this LCD has no PWM pin connected
     // PWM Config
     gpio_set_function(LCD_BL_PIN, GPIO_FUNC_PWM);
     slice_num = pwm_gpio_to_slice_num(LCD_BL_PIN);
@@ -157,7 +156,6 @@ UBYTE DEV_Module_Init(void)
     pwm_set_chan_level(slice_num, PWM_CHAN_B, 1);
     pwm_set_clkdiv(slice_num,50);
     pwm_set_enabled(slice_num, true);
-#endif
 
 #if 0	// this LCD has no I2C pin connected
     //I2C Config

--- a/lcd/Config/DEV_Config.h
+++ b/lcd/Config/DEV_Config.h
@@ -48,7 +48,7 @@
 
 #define LCD_RST_PIN  12
 #define LCD_DC_PIN   8
-#define LCD_BL_PIN   13
+#define LCD_BL_PIN   25
     
 #define LCD_CS_PIN   9
 #define LCD_CLK_PIN  10


### PR DESCRIPTION
Turns out the RP2040 GEEK has a PWM LCD backlight LED pin.

The schematic ( https://files.waveshare.com/wiki/RP2040-GEEK/RP2040-GEEK-Schematic.pdf ) shows the right pin (GPIO25).