### PR TITLE
add board definition file and some settings to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,21 @@
-cmake_minimum_required(VERSION 3.12)
-set (PICO_BOARD pico)
+cmake_minimum_required(VERSION 3.13)
+
+# Set default build type to Release
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+set(CMAKE_BUILD_TYPE Release)
+endif()
+
+set(PICO_BOARD_HEADER_DIRS ${CMAKE_SOURCE_DIR})
+
+# Set platform, board, and compiler
+set(PICO_PLATFORM rp2040)
+set(PICO_BOARD waveshare_rp2040_geek)
+set(PICO_COMPILER pico_arm_gcc)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_CXX_STANDARD 17)
+
+# Pull in SDK (must be before project)
 include(pico_sdk_import.cmake)
 
 project(picosim C CXX ASM)
@@ -52,6 +68,17 @@ target_compile_definitions(picosim INTERFACE
 	PICO_DEFAULT_UART=0
 )
 
+target_compile_options(picosim PUBLIC
+	### GNU/Clang C Options
+	$<$<COMPILE_LANG_AND_ID:C,GNU>:-fdiagnostics-color=always>
+	$<$<COMPILE_LANG_AND_ID:C,Clang>:-fcolor-diagnostics>
+
+	$<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wall>
+	$<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wextra>
+	$<$<COMPILE_LANG_AND_ID:C,Clang>:-Weverything>
+	$<$<COMPILE_LANG_AND_ID:C,Clang,GNU>:-Wno-unused-parameter>
+	)
+
 target_link_libraries(picosim
 	pico_stdlib
 	no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
@@ -64,8 +91,12 @@ target_link_libraries(picosim
 
 pico_add_extra_outputs(picosim)
 
+set_property(TARGET picosim APPEND_STRING PROPERTY LINK_FLAGS "-Wl,--print-memory-usage")
+
 pico_set_program_name(picosim "z80pack picosim")
+pico_set_program_description(picosim "z80pack on Waveshare RP2040-GEEK")
 pico_set_program_version(picosim "1.2")
+pico_set_program_url(picosim "https://github.com/udo-munk/RP2040-GEEK-80")
 
 # disable UART in/out, enable USB in/out
 pico_enable_stdio_uart(picosim 0)

--- a/config.c
+++ b/config.c
@@ -124,7 +124,8 @@ again:
 			printf("Value in Hex: ");
 			get_cmdline(s, 3);
 			printf("\n\n");
-			if (!isxdigit(*s) || !isxdigit(*(s + 1))) {
+			if (!isxdigit((unsigned char) *s) ||
+			    !isxdigit((unsigned char) *(s + 1))) {
 				printf("What?\n");
 				goto again;
 			}

--- a/waveshare_rp2040_geek.h
+++ b/waveshare_rp2040_geek.h
@@ -1,0 +1,105 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+// -----------------------------------------------------
+// NOTE: THIS HEADER IS ALSO INCLUDED BY ASSEMBLER SO
+//       SHOULD ONLY CONSIST OF PREPROCESSOR DIRECTIVES
+// -----------------------------------------------------
+
+
+#ifndef _BOARDS_WAVESHARE_RP2040_GEEK_H
+#define _BOARDS_WAVESHARE_RP2040_GEEK_H
+
+// For board detection
+#define WAVESHARE_RP2040_GEEK
+
+// --- UART ---
+#ifndef PICO_DEFAULT_UART
+#define PICO_DEFAULT_UART 0
+#endif
+#ifndef PICO_DEFAULT_UART_TX_PIN
+#define PICO_DEFAULT_UART_TX_PIN 4
+#endif
+#ifndef PICO_DEFAULT_UART_RX_PIN
+#define PICO_DEFAULT_UART_RX_PIN 5
+#endif
+
+// Has debug probe pins on GPIO2 and GPIO3
+
+// no PICO_DEFAULT_LED_PIN
+// no PICO_DEFAULT_WS2812_PIN
+
+// --- I2C ---
+#ifndef PICO_DEFAULT_I2C
+#define PICO_DEFAULT_I2C 0
+#endif
+#ifndef PICO_DEFAULT_I2C_SDA_PIN
+#define PICO_DEFAULT_I2C_SDA_PIN 28
+#endif
+#ifndef PICO_DEFAULT_I2C_SCL_PIN
+#define PICO_DEFAULT_I2C_SCL_PIN 29
+#endif
+
+// --- SD CARD ---
+#ifndef PICO_SD_CLK_PIN
+#define PICO_SD_CLK_PIN 18
+#endif
+#ifndef PICO_SD_CMD_PIN
+#define PICO_SD_CMD_PIN 19
+#endif
+#ifndef PICO_SD_DAT0_PIN
+#define PICO_SD_DAT0_PIN 20
+#endif
+// 1 or 4
+#ifndef PICO_SD_DAT_PIN_COUNT
+#define PICO_SD_DAT_PIN_COUNT 4
+#endif
+// 1 or -1
+#ifndef PICO_SD_DAT_PIN_INCREMENT
+#define PICO_SD_DAT_PIN_INCREMENT 1
+#endif
+
+// --- LCD ---
+#ifndef WAVESHARE_RP2040_LCD_SPI
+#define WAVESHARE_RP2040_LCD_SPI 1
+#endif
+#ifndef WAVESHARE_RP2040_LCD_DC_PIN
+#define WAVESHARE_RP2040_LCD_DC_PIN 8
+#endif
+#ifndef WAVESHARE_RP2040_LCD_CS_PIN
+#define WAVESHARE_RP2040_LCD_CS_PIN 9
+#endif
+#ifndef WAVESHARE_RP2040_LCD_SCLK_PIN
+#define WAVESHARE_RP2040_LCD_SCLK_PIN 10
+#endif
+#ifndef WAVESHARE_RP2040_LCD_TX_PIN
+#define WAVESHARE_RP2040_LCD_TX_PIN 11
+#endif
+#ifndef WAVESHARE_RP2040_LCD_RST_PIN
+#define WAVESHARE_RP2040_LCD_RST_PIN 12
+#endif
+#ifndef WAVESHARE_RP2040_LCD_BL_PIN
+#define WAVESHARE_RP2040_LCD_BL_PIN 25
+#endif
+
+// --- FLASH ---
+
+#define PICO_BOOT_STAGE2_CHOOSE_W25Q080 1
+
+#ifndef PICO_FLASH_SPI_CLKDIV
+#define PICO_FLASH_SPI_CLKDIV 2
+#endif
+
+#ifndef PICO_FLASH_SIZE_BYTES
+#define PICO_FLASH_SIZE_BYTES (4 * 1024 * 1024)
+#endif
+
+// All boards have B1 RP2040
+#ifndef PICO_RP2040_B0_SUPPORTED 
+#define PICO_RP2040_B0_SUPPORTED  0
+#endif
+
+#endif


### PR DESCRIPTION
Add a board definition file for the Waveshare RP2040-GEEK.

-Wunused-parameter is disabled because no-OS-FatFS-SD-SDIO-SPI-RPi-Pico isn't clean.