### PR TITLE
when using USB UART allow break to act as interrupt

### DIFF
--- a/picosim.c
+++ b/picosim.c
@@ -109,6 +109,17 @@ sd_card_t *sd_get_by_num(size_t num) {
 	}
 }
 
+#if LIB_PICO_STDIO_USB
+void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms)
+{
+	UNUSED(itf);
+	UNUSED(duration_ms);
+
+	cpu_error = USERINT;
+	cpu_state = STOPPED;
+}
+#endif
+
 int main(void)
 {
 	stdio_init_all();	/* initialize Pico stdio */


### PR DESCRIPTION
The tinyusb version in pico-sdk doesn't advertise that it can handle breaks. This was already fixed in the tinyusb repository. The following patch needs to be applied to pico-sdk/lib/tinyusb/src/device/usbd.h:

```
diff --git a/src/device/usbd.h b/src/device/usbd.h
index ad19d1045..8f064bc6d 100644
--- a/src/device/usbd.h
+++ b/src/device/usbd.h
@@ -217,8 +217,8 @@ TU_ATTR_WEAK bool tud_vendor_control_xfer_cb(uint8_t rhport, uint8_t stage, tusb
   5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_HEADER, U16_TO_U8S_LE(0x0120),\
   /* CDC Call */\
   5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_CALL_MANAGEMENT, 0, (uint8_t)((_itfnum) + 1),\
-  /* CDC ACM: support line request */\
-  4, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT, 2,\
+  /* CDC ACM: support line request + send break */\
+  4, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_ABSTRACT_CONTROL_MANAGEMENT, 6,\
   /* CDC Union */\
   5, TUSB_DESC_CS_INTERFACE, CDC_FUNC_DESC_UNION, _itfnum, (uint8_t)((_itfnum) + 1),\
   /* Endpoint Notification */\
```