### PR TITLE
add USB mass storage support & disks clean-up

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -71,6 +71,12 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	LCD_COLOR_DEPTH=12
 	# LCD refresh rate in Hz (30 works well with 12-bit frame buffer)
 	LCD_REFRESH=30
+	# USB vendor and product id's.
+	# This is the pid.codes private testing VID/PID, this is not
+	# universally unique and should not be used outside test environments.
+	# See https://pid.codes/1209/1001
+	USBD_VID=0x1209
+	USBD_PID=0x0001
 )
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE
@@ -96,6 +102,7 @@ target_link_libraries(${PROJECT_NAME}
 	pico_multicore
 	pico_stdlib
 	stdio_msc_usb
+	tinyusb_device
 	no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
 	Config
 	Fonts

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,38 +19,41 @@ set(CMAKE_CXX_STANDARD 17)
 include(pico_sdk_import.cmake)
 
 project(picosim C CXX ASM)
+
 pico_sdk_init()
 
-include_directories(
-	.
-	../z80pack/z80core
-	../z80pack/iodevices
-	./lcd/Config
-	./lcd/Fonts
-	./lcd/GUI
-	./lcd/LCD
-)
+set(Z80PACK ${CMAKE_SOURCE_DIR}/../z80pack)
 
-add_executable(picosim
+add_executable(${PROJECT_NAME}
 	picosim.c
-	../z80pack/z80core/simcore.c
-	../z80pack/z80core/simglb.c
-	../z80pack/z80core/simdis.c
-	../z80pack/z80core/simice.c
-	../z80pack/z80core/sim8080.c
-	../z80pack/z80core/simz80.c
-	../z80pack/z80core/simz80-cb.c
-	../z80pack/z80core/simz80-dd.c
-	../z80pack/z80core/simz80-ddcb.c
-	../z80pack/z80core/simz80-ed.c
-	../z80pack/z80core/simz80-fd.c
-	../z80pack/z80core/simz80-fdcb.c
-	../z80pack/iodevices/sd-fdc.c
 	config.c
 	dazzler.c
-	memsim.c
 	iosim.c
 	lcd.c
+	memsim.c
+	${Z80PACK}/iodevices/sd-fdc.c
+	${Z80PACK}/z80core/sim8080.c
+	${Z80PACK}/z80core/simcore.c
+	${Z80PACK}/z80core/simdis.c
+	${Z80PACK}/z80core/simglb.c
+	${Z80PACK}/z80core/simice.c
+	${Z80PACK}/z80core/simz80-cb.c
+	${Z80PACK}/z80core/simz80-dd.c
+	${Z80PACK}/z80core/simz80-ddcb.c
+	${Z80PACK}/z80core/simz80-ed.c
+	${Z80PACK}/z80core/simz80-fd.c
+	${Z80PACK}/z80core/simz80-fdcb.c
+	${Z80PACK}/z80core/simz80.c
+)
+
+target_include_directories(${PROJECT_NAME} PUBLIC
+	${CMAKE_SOURCE_DIR}
+	${CMAKE_SOURCE_DIR}/lcd/Config
+	${CMAKE_SOURCE_DIR}/lcd/Fonts
+	${CMAKE_SOURCE_DIR}/lcd/GUI
+	${CMAKE_SOURCE_DIR}/lcd/LCD
+	${Z80PACK}/iodevices
+	${Z80PACK}/z80core
 )
 
 add_subdirectory(no-OS-FatFS-SD-SDIO-SPI-RPi-Pico/src FatFs)
@@ -58,8 +61,9 @@ add_subdirectory(lcd/Config)
 add_subdirectory(lcd/LCD)
 add_subdirectory(lcd/Fonts)
 add_subdirectory(lcd/GUI)
+add_subdirectory(stdio_msc_usb)
 
-target_compile_definitions(picosim PRIVATE
+target_compile_definitions(${PROJECT_NAME} PRIVATE
 	PICO_STACK_SIZE=4096
 	PICO_CORE1_STACK_SIZE=4096
 	PICO_HEAP_SIZE=8192
@@ -69,44 +73,45 @@ target_compile_definitions(picosim PRIVATE
 	LCD_REFRESH=30
 )
 
-target_compile_definitions(picosim INTERFACE
+target_compile_definitions(${PROJECT_NAME} INTERFACE
 	PICO_DEFAULT_UART=0
 )
 
 # compiler diagnostic options
 if (PICO_C_COMPILER_IS_GNU)
-	target_compile_options(picosim PUBLIC -fdiagnostics-color=always)
+	target_compile_options(${PROJECT_NAME} PUBLIC -fdiagnostics-color=always)
 elseif (PICO_C_COMPILER_IS_CLANG)
-	target_compile_options(picosim PUBLIC -fcolor-diagnostics)
+	target_compile_options(${PROJECT_NAME} PUBLIC -fcolor-diagnostics)
 endif ()
-target_compile_options(picosim PUBLIC -Wall -Wextra)
+target_compile_options(${PROJECT_NAME} PUBLIC -Wall -Wextra)
 if (PICO_C_COMPILER_IS_CLANG)
-	target_compile_options(picosim PUBLIC -Weverything)
+	target_compile_options(${PROJECT_NAME} PUBLIC -Weverything)
 endif ()
 # -Wno-unused-parameter because no-OS-FatFS-SD-SDIO-SPI-RPi-Pico isn't clean
-target_compile_options(picosim PUBLIC -Wno-unused-parameter)
+target_compile_options(${PROJECT_NAME} PUBLIC -Wno-unused-parameter)
 
-target_link_libraries(picosim
+target_link_libraries(${PROJECT_NAME}
 	hardware_adc
 	hardware_spi
 	pico_multicore
 	pico_stdlib
+	stdio_msc_usb
 	no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
 	Config
-	LCD
 	Fonts
 	GUI
+	LCD
 )
 
-pico_add_extra_outputs(picosim)
+pico_add_extra_outputs(${PROJECT_NAME})
 
-target_link_options(picosim PRIVATE -Xlinker --print-memory-usage)
+target_link_options(${PROJECT_NAME} PRIVATE -Xlinker --print-memory-usage)
 
-pico_set_program_name(picosim "z80pack picosim")
-pico_set_program_description(picosim "z80pack on Waveshare RP2040-GEEK")
-pico_set_program_version(picosim "1.2")
-pico_set_program_url(picosim "https://github.com/udo-munk/RP2040-GEEK-80")
+pico_set_program_name(${PROJECT_NAME} "z80pack picosim")
+pico_set_program_description(${PROJECT_NAME} "z80pack on Waveshare RP2040-GEEK")
+pico_set_program_version(${PROJECT_NAME} "1.2")
+pico_set_program_url(${PROJECT_NAME} "https://github.com/udo-munk/RP2040-GEEK-80")
 
 # disable UART in/out, enable USB in/out
-pico_enable_stdio_uart(picosim 0)
-pico_enable_stdio_usb(picosim 1)
+pico_enable_stdio_uart(${PROJECT_NAME} 0)
+# pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,6 +28,7 @@ add_executable(${PROJECT_NAME}
 	picosim.c
 	config.c
 	dazzler.c
+	disks.c
 	iosim.c
 	lcd.c
 	memsim.c

--- a/config.c
+++ b/config.c
@@ -39,9 +39,10 @@ extern FATFS fs;
 
 extern int get_cmdline(char *, int);
 extern void switch_cpu(int);
+extern void list_files(const char *, const char *);
 extern void load_file(char *);
+extern void check_disks(void);
 extern void mount_disk(int, char *);
-extern void my_ls(const char *, const char *);
 extern unsigned char fp_value;
 
 /*
@@ -195,12 +196,13 @@ void config(void)
 			msc_ejected = false;
 			while (!msc_ejected)
 				sleep_ms(500);
-			puts("Disk ejected");
+			puts("Disk ejected\n");
 			/* try to mount SD card */
 			sd_res = f_mount(&fs, "", 1);
 			if (sd_res != FR_OK)
 				panic("f_mount error: %s (%d)\n",
 				      FRESULT_str(sd_res), sd_res);
+			check_disks();
 			break;
 
 		case 'c':
@@ -224,7 +226,7 @@ again:
 			putchar('\n');
 			if (!isxdigit((unsigned char) *s) ||
 			    !isxdigit((unsigned char) *(s + 1))) {
-				printf("What?\n");
+				puts("What?");
 				goto again;
 			}
 			fp_value = (*s <= '9' ? *s - '0' : *s - 'A' + 10) << 4;
@@ -233,8 +235,8 @@ again:
 			break;
 
 		case 'f':
-			my_ls(cpath, cext);
-			printf("\n\n");
+			list_files(cpath, cext);
+			putchar('\n');
 			break;
 
 		case 'r':
@@ -244,8 +246,8 @@ again:
 			break;
 
 		case 'd':
-			my_ls(dpath, dext);
-			printf("\n\n");
+			list_files(dpath, dext);
+			putchar('\n');
 			break;
 
 		case '0':

--- a/disks.c
+++ b/disks.c
@@ -10,6 +10,7 @@
  * 27-MAY-2024 implemented load file
  * 28-MAY-2024 implemented sector I/O to disk images
  * 03-JUN-2024 added directory list for code files and disk images
+ * 29-JUN-2024 split of from memsim.c and picosim.c
  */
 
 #include <stdint.h>

--- a/disks.c
+++ b/disks.c
@@ -1,0 +1,346 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 2024 by Udo Munk & Thomas Eberhardt
+ *
+ * This module implements the disks drives and low level
+ * access functions for MicroSD, needed by the FDC.
+ *
+ * History:
+ * 27-MAY-2024 implemented load file
+ * 28-MAY-2024 implemented sector I/O to disk images
+ * 03-JUN-2024 added directory list for code files and disk images
+ */
+
+#include <stdint.h>
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include "f_util.h"
+#include "ff.h"
+#include "hw_config.h"
+#include "sim.h"
+#include "simglb.h"
+#include "memsim.h"
+#include "disks.h"
+#include "sd-fdc.h"
+
+FIL sd_file;	/* at any time we have only one file open */
+FRESULT sd_res;	/* result code from FatFS */
+char disks[NUMDISK][DISKLEN]; /* path name for 4 disk images /DISKS80/filename.DSK */
+
+static FATFS fs; /* FatFs on MicroSD */
+
+/* buffer for disk/memory transfers */
+static unsigned char dsk_buf[SEC_SZ];
+
+/* global variables for access to MicroSD card */
+
+/*
+ * In the RP2024-GEEK the MicroSD card is connected to the MCU GPIO's
+ * so that it either can be accessed with SPI or with SDIO. First it
+ * was tested with SPI and then with SDIO, which is active because
+ * data transfers are faster.
+ */
+
+#if 0
+/* Configuration of RP2040 hardware SPI object */
+static spi_t spi = {
+	.hw_inst = spi0,  /* RP2040 SPI component */
+	.sck_gpio = 18,   /* GPIO number (not Pico pin number) */
+	.mosi_gpio = 19,
+	.miso_gpio = 20,
+	.baud_rate = 12 * 1000 * 1000 /* Actual frequency: 10416666 */
+};
+
+/* SPI Interface */
+static sd_spi_if_t spi_if = {
+	.spi = &spi,  /* Pointer to the SPI driving this card */
+	.ss_gpio = 23 /* The SPI slave select GPIO for this SD card */
+};
+
+/* Configuration of the SD Card socket object */
+static sd_card_t sd_card = {
+	.type = SD_IF_SPI,
+	.spi_if_p = &spi_if /* Pointer to the SPI interface driving this card */
+};
+#endif
+
+/* SDIO Interface */
+static sd_sdio_if_t sdio_if = {
+	.CMD_gpio = 19,
+	.D0_gpio = 20,
+	.baud_rate = 15 * 1000 * 1000 /* 15 MHz */
+};
+
+/* Configuration of the SD Card socket object */
+static sd_card_t sd_card = {
+	.type = SD_IF_SDIO,
+	.sdio_if_p = &sdio_if
+};
+
+/* Callbacks used by the SD library */
+
+size_t sd_get_num(void)
+{
+	return 1;
+}
+
+sd_card_t *sd_get_by_num(size_t num)
+{
+	if (num == 0) {
+		return &sd_card;
+	} else {
+		return NULL;
+	}
+}
+
+void init_disks(void)
+{
+	/* try to mount SD card */
+	sd_res = f_mount(&fs, "", 1);
+	if (sd_res != FR_OK)
+		panic("f_mount error: %s (%d)\n", FRESULT_str(sd_res), sd_res);
+}
+
+void exit_disks(void)
+{
+	/* unmount SD card */
+	f_unmount("");
+}
+
+/*
+ * list files with pattern 'ext' in directory 'dir'
+ */
+void list_files(const char *dir, const char *ext)
+{
+	DIR dp;
+	FILINFO fno;
+	FRESULT res;
+	register int i = 0;
+
+	res = f_findfirst(&dp, &fno, dir, ext);
+	if (res == FR_OK) {
+		while (1) {
+			printf("%s\t", fno.fname);
+			if (strlen(fno.fname) < 8)
+				putchar('\t');
+			i++;
+			if (i > 4) {
+				putchar('\n');
+				i = 0;
+			}
+			res = f_findnext(&dp, &fno);
+			if (!strlen(fno.fname)) {
+				if (i > 0)
+					putchar('\n');
+				break;
+			}
+		}
+	}
+}
+
+/*
+ * load a file 'name' into memory
+ */
+void load_file(const char *name)
+{
+	int i = 0;
+	register unsigned int j;
+	unsigned int br;
+	char SFN[25];
+
+	strcpy(SFN, "/CODE80/");
+	strcat(SFN, name);
+	strcat(SFN, ".BIN");
+
+	/* try to open file */
+	sd_res = f_open(&sd_file, SFN, FA_READ);
+	if (sd_res != FR_OK) {
+		puts("File not found");
+		return;
+	}
+
+	/* read file into memory */
+	while ((sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br)) == FR_OK) {
+		for (j = 0; j < br; j++)
+			dma_write(i + j, dsk_buf[j]);
+		if (br < SEC_SZ)	/* last record reached */
+			break;
+		i += SEC_SZ;
+	}
+	if (sd_res != FR_OK)
+		printf("f_read error: %s (%d)\n", FRESULT_str(sd_res), sd_res);
+	else
+		printf("loaded file \"%s\" (%d bytes)\n", SFN, i + br);
+
+	f_close(&sd_file);
+}
+
+/*
+ * check that all disks refer to existing files
+ */
+void check_disks(void)
+{
+	int i, n = 0;
+
+	for (i = 0; i < NUMDISK; i++) {
+		if (disks[i][0]) {
+			/* try to open file */
+			sd_res = f_open(&sd_file, disks[i], FA_READ);
+			if (sd_res != FR_OK) {
+				printf("Disk image \"%s\" no longer exists.\n",
+				       disks[i]);
+				disks[i][0] = '\0';
+				n++;
+			} else
+				f_close(&sd_file);
+		}
+	}
+	if (n > 0)
+		putchar('\n');
+}
+
+/*
+ * mount a disk image 'name' on disk 'drive'
+ */
+void mount_disk(int drive, const char *name)
+{
+	char SFN[DISKLEN];
+	int i;
+
+	strcpy(SFN, "/DISKS80/");
+	strcat(SFN, name);
+	strcat(SFN, ".DSK");
+
+	for (i = 0; i < NUMDISK; i++) {
+		if (i != drive && strcmp(disks[i], SFN) == 0) {
+			puts("Disk already mounted\n");
+			return;
+		}
+	}
+
+	/* try to open file */
+	sd_res = f_open(&sd_file, SFN, FA_READ);
+	if (sd_res != FR_OK) {
+		puts("File not found\n");
+		return;
+	}
+
+	f_close(&sd_file);
+	strcpy(disks[drive], SFN);
+	putchar('\n');
+}
+
+/*
+ * prepare I/O for sector read and write routines
+ */
+static BYTE prep_io(int drive, int track, int sector, WORD addr)
+{
+	FSIZE_t pos;
+
+	/* check if drive in range */
+	if ((drive < 0) || (drive > 3))
+		return FDC_STAT_DISK;
+
+	/* check if track and sector in range */
+	if (track > TRK)
+		return FDC_STAT_TRACK;
+	if ((sector < 1) || (sector > SPT))
+		return FDC_STAT_SEC;
+
+	/* check if DMA address in range */
+	if (addr > 0xff7f)
+		return FDC_STAT_DMAADR;
+
+	/* check if disk in drive */
+	if (!strlen(disks[drive])) {
+		return FDC_STAT_NODISK;
+	}
+
+	/* open file with the disk image */
+	sd_res = f_open(&sd_file, disks[drive], FA_READ | FA_WRITE);
+	if (sd_res != FR_OK)
+		return FDC_STAT_NODISK;
+
+	/* seek to track/sector */
+	pos = (((FSIZE_t) track * (FSIZE_t) SPT) + sector - 1) * SEC_SZ;
+	if (f_lseek(&sd_file, pos) != FR_OK) {
+		f_close(&sd_file);
+		return FDC_STAT_SEEK;
+	}
+	return FDC_STAT_OK;
+}
+
+/*
+ * read from drive a sector on track into memory @ addr
+ */
+BYTE read_sec(int drive, int track, int sector, WORD addr)
+{
+	BYTE stat;
+	unsigned int br;
+	register int i;
+
+	/* prepare for sector read */
+	if ((stat = prep_io(drive, track, sector, addr)) != FDC_STAT_OK)
+		return stat;
+
+	/* read sector into memory */
+	sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br);
+	if (sd_res == FR_OK) {
+		if (br < SEC_SZ) {	/* UH OH */
+			f_close(&sd_file);
+			return FDC_STAT_READ;
+		} else {
+			f_close(&sd_file);
+			for (i = 0; i < SEC_SZ; i++)
+				dma_write(addr + i, dsk_buf[i]);
+			return FDC_STAT_OK;
+		}
+	} else {
+		f_close(&sd_file);
+		return FDC_STAT_READ;
+	}
+}
+
+/*
+ * write to drive a sector on track from memory @ addr
+ */
+BYTE write_sec(int drive, int track, int sector, WORD addr)
+{
+	BYTE stat;
+	unsigned int br;
+	register int i;
+
+	/* prepare for sector write */
+	if ((stat = prep_io(drive, track, sector, addr)) != FDC_STAT_OK)
+		return stat;
+
+	/* write sector to disk image */
+	for (i = 0; i < SEC_SZ; i++)
+		dsk_buf[i] = dma_read(addr + i);
+	sd_res = f_write(&sd_file, &dsk_buf[0], SEC_SZ, &br);
+	if (sd_res == FR_OK) {
+		if (br < SEC_SZ) {	/* UH OH */
+			f_close(&sd_file);
+			return FDC_STAT_WRITE;
+		} else {
+			f_close(&sd_file);
+			return FDC_STAT_OK;
+		}
+	} else {
+		f_close(&sd_file);
+		return FDC_STAT_WRITE;
+	}
+}
+
+/*
+ * get FDC command from CPU memory
+ */
+void get_fdccmd(BYTE *cmd, WORD addr)
+{
+	register int i;
+
+	for (i = 0; i < 4; i++)
+		cmd[i] = dma_read(addr + i);
+}

--- a/disks.h
+++ b/disks.h
@@ -1,0 +1,28 @@
+/*
+ * Z80SIM  -  a Z80-CPU simulator
+ *
+ * Copyright (C) 2024 by Udo Munk & Thomas Eberhardt
+ *
+ * This module implements the disks drives and low level
+ * access functions for MicroSD, needed by the FDC.
+ *
+ * History:
+ * 29-JUN-2024 split of from memsim.c and picosim.c
+ */
+
+#define NUMDISK	4	/* number of disk drives */
+#define DISKLEN	22	/* path length for disk drives /DISKS80/filename.DSK */
+
+extern FIL sd_file;
+extern FRESULT sd_res;
+extern char disks[NUMDISK][DISKLEN];
+
+extern void init_disks(void), exit_disks(void);
+extern void list_files(const char *, const char *);
+extern void load_file(const char *);
+extern void check_disks(void);
+extern void mount_disk(int, const char *name);
+
+extern BYTE read_sec(int, int, int, WORD);
+extern BYTE write_sec(int, int, int, WORD);
+extern void get_fdccmd(BYTE *, WORD);

--- a/iosim.c
+++ b/iosim.c
@@ -18,7 +18,7 @@
 
 /* Raspberry SDK includes */
 #include <stdio.h>
-#if LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 #include <tusb.h>
 #endif
 #include "pico/stdlib.h"
@@ -107,7 +107,7 @@ static BYTE p000_in(void)
 	if (uart_is_readable(my_uart))	/* check if there is input from UART */
 		stat &= 0b11111110;	/* if so flip status bit */
 #endif
-#if LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 	if (tud_cdc_write_available())	/* check if output to UART is possible */
 		stat &= 0b01111111;	/* if so flip status bit */
 	if (tud_cdc_available())	/* check if there is input from UART */
@@ -123,15 +123,15 @@ static BYTE p000_in(void)
  */
 static BYTE p001_in(void)
 {
-#if LIB_PICO_STDIO_UART && !LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_UART && !(LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB)
 	uart_inst_t *my_uart = PICO_DEFAULT_UART_INSTANCE;
 
 	if (!uart_is_readable(my_uart))
 #endif
-#if LIB_PICO_STDIO_USB && !LIB_PICO_STDIO_UART
+#if (LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB) && !LIB_PICO_STDIO_UART
 	if (!tud_cdc_available())
 #endif
-#if LIB_PICO_STDIO_USB && LIB_PICO_STDIO_UART
+#if (LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB) && LIB_PICO_STDIO_UART
 	uart_inst_t *my_uart = PICO_DEFAULT_UART_INSTANCE;
 
 	if (!uart_is_readable(my_uart) && !tud_cdc_available())

--- a/lcd.c
+++ b/lcd.c
@@ -107,7 +107,7 @@ void lcd_default_draw_func(void)
  *	1 DE 1234  HL 1234
  *	2 SP 1234  PC 1234
  *	3 F  SZHPC    IF 1
- *	4 info_line (Font 20)
+ *	4 info_line xx.xxC (Font 20)
  */
 
 #if LCD_COLOR_DEPTH == 12

--- a/lcd/LCD/LCD_1in14_V2.c
+++ b/lcd/LCD/LCD_1in14_V2.c
@@ -102,10 +102,10 @@ static void  __not_in_flash_func(LCD_1IN14_V2_InitReg)(void)
 	LCD_1IN14_V2_SendData_8Bit(0x33); /* Back/Front porch partial (3, 3) */
 
 	LCD_1IN14_V2_SendCommand(0xb7); /* Gate Control */
-	LCD_1IN14_V2_SendData_8Bit(0x35);/* VGH=13.26V, VGL=-10.43V */
+	LCD_1IN14_V2_SendData_8Bit(0x35);/* VGH = 13.26V, VGL = -10.43V */
 
 	LCD_1IN14_V2_SendCommand(0xbb); /* VCOM Setting */
-	LCD_1IN14_V2_SendData_8Bit(0x19); /* VCOM=0.725V */
+	LCD_1IN14_V2_SendData_8Bit(0x19); /* VCOM = 0.725V */
 
 	LCD_1IN14_V2_SendCommand(0xc0); /* LCM Control */
 	LCD_1IN14_V2_SendData_8Bit(0x2c); /* XBGR, XMX, XMH (default) */
@@ -113,50 +113,51 @@ static void  __not_in_flash_func(LCD_1IN14_V2_InitReg)(void)
 	LCD_1IN14_V2_SendCommand(0xc2); /* VDV and VRH Command Enable */
 	LCD_1IN14_V2_SendData_8Bit(0x01); /* VDV & VRH from command write */
 	LCD_1IN14_V2_SendCommand(0xc3); /* VRH Set */
-	LCD_1IN14_V2_SendData_8Bit(0x12); /* 4.45V+(vcom+offset+vdv)=5.175V */
+	LCD_1IN14_V2_SendData_8Bit(0x12); /* VRH = 4.45V */
 	LCD_1IN14_V2_SendCommand(0xc4); /* VDV Set */
-	LCD_1IN14_V2_SendData_8Bit(0x20); /* 0V (default) */
+	LCD_1IN14_V2_SendData_8Bit(0x20); /* VDV = 0V (default) */
 	LCD_1IN14_V2_SendCommand(0xc5); /* VCOM Offset Set */
-	LCD_1IN14_V2_SendData_8Bit(0x20); /* 0V (default) */
+	LCD_1IN14_V2_SendData_8Bit(0x20); /* VCOM Offset = 0V (default) */
 
 	LCD_1IN14_V2_SendCommand(0xc6); /* Frame Rate Control in Normal Mode */
-	LCD_1IN14_V2_SendData_8Bit(0x0f); /* 60Hz */
+	LCD_1IN14_V2_SendData_8Bit(0x0f); /* 60Hz (default) */
 
 	LCD_1IN14_V2_SendCommand(0xd0); /* Power Control 1 */
 	LCD_1IN14_V2_SendData_8Bit(0xa4); /* fixed parameter */
-	LCD_1IN14_V2_SendData_8Bit(0xa1); /* AVDD=6.8V, AVCL=-4.8V, VDS=2.3V */
+	LCD_1IN14_V2_SendData_8Bit(0xa1); /* AVDD = 6.8V, AVCL = -4.8V,
+					     VDDS = 2.3V */
 
 	LCD_1IN14_V2_SendCommand(0xe0); /* Positive Voltage Gamma Control */
-	LCD_1IN14_V2_SendData_8Bit(0xd0); /* VP63=13, VP0=0 */
-	LCD_1IN14_V2_SendData_8Bit(0x04); /* VP1=4 */
-	LCD_1IN14_V2_SendData_8Bit(0x0d); /* VP2=13 */
-	LCD_1IN14_V2_SendData_8Bit(0x11); /* VP4=17 */
-	LCD_1IN14_V2_SendData_8Bit(0x13); /* VP6=19 */
-	LCD_1IN14_V2_SendData_8Bit(0x2b); /* JP0=2, VP13=11 */
-	LCD_1IN14_V2_SendData_8Bit(0x3f); /* VP20=63 */
-	LCD_1IN14_V2_SendData_8Bit(0x54); /* VP36=5, VP27=4 */
-	LCD_1IN14_V2_SendData_8Bit(0x4c); /* VP43=76 */
-	LCD_1IN14_V2_SendData_8Bit(0x18); /* JP1=1, VP50=8 */
-	LCD_1IN14_V2_SendData_8Bit(0x0d); /* VP57=13 */
-	LCD_1IN14_V2_SendData_8Bit(0x0b); /* VP59=11 */
-	LCD_1IN14_V2_SendData_8Bit(0x1f); /* VP61=31 */
-	LCD_1IN14_V2_SendData_8Bit(0x23); /* VP62=35 */
+	LCD_1IN14_V2_SendData_8Bit(0xd0); /* V63P = 13, V0P = 0 */
+	LCD_1IN14_V2_SendData_8Bit(0x04); /* V1P = 4 */
+	LCD_1IN14_V2_SendData_8Bit(0x0d); /* V2P = 13 */
+	LCD_1IN14_V2_SendData_8Bit(0x11); /* V4P = 17 */
+	LCD_1IN14_V2_SendData_8Bit(0x13); /* V6P = 19 */
+	LCD_1IN14_V2_SendData_8Bit(0x2b); /* J0P = 2, V13P = 11 */
+	LCD_1IN14_V2_SendData_8Bit(0x3f); /* V20P = 63 */
+	LCD_1IN14_V2_SendData_8Bit(0x54); /* V36P = 5, V27P = 4 */
+	LCD_1IN14_V2_SendData_8Bit(0x4c); /* V43P = 76 */
+	LCD_1IN14_V2_SendData_8Bit(0x18); /* J1P = 1, V50P = 8 */
+	LCD_1IN14_V2_SendData_8Bit(0x0d); /* V57P = 13 */
+	LCD_1IN14_V2_SendData_8Bit(0x0b); /* V59P = 11 */
+	LCD_1IN14_V2_SendData_8Bit(0x1f); /* V61P = 31 */
+	LCD_1IN14_V2_SendData_8Bit(0x23); /* V62P = 35 */
 
 	LCD_1IN14_V2_SendCommand(0xe1); /* Negative Voltage Gamma Control */
-	LCD_1IN14_V2_SendData_8Bit(0xd0); /* VN63=13, VN0=0 */
-	LCD_1IN14_V2_SendData_8Bit(0x04); /* VN1=4 */
-	LCD_1IN14_V2_SendData_8Bit(0x0c); /* VN2=12 */
-	LCD_1IN14_V2_SendData_8Bit(0x11); /* VN4=17 */
-	LCD_1IN14_V2_SendData_8Bit(0x13); /* VN6=19 */
-	LCD_1IN14_V2_SendData_8Bit(0x2c); /* JN0=2, VN13=12 */
-	LCD_1IN14_V2_SendData_8Bit(0x3f); /* VN20=63 */
-	LCD_1IN14_V2_SendData_8Bit(0x44); /* VN36=4, VN27=4 */
-	LCD_1IN14_V2_SendData_8Bit(0x51); /* VN43=81 */
-	LCD_1IN14_V2_SendData_8Bit(0x2f); /* JN1=2, VN50=15 */
-	LCD_1IN14_V2_SendData_8Bit(0x1f); /* VN57=31 */
-	LCD_1IN14_V2_SendData_8Bit(0x1f); /* VN59=31 */
-	LCD_1IN14_V2_SendData_8Bit(0x20); /* VN61=32 */
-	LCD_1IN14_V2_SendData_8Bit(0x23); /* VN62=35 */
+	LCD_1IN14_V2_SendData_8Bit(0xd0); /* V63N = 13, V0N = 0 */
+	LCD_1IN14_V2_SendData_8Bit(0x04); /* V1N = 4 */
+	LCD_1IN14_V2_SendData_8Bit(0x0c); /* V2N = 12 */
+	LCD_1IN14_V2_SendData_8Bit(0x11); /* V4N = 17 */
+	LCD_1IN14_V2_SendData_8Bit(0x13); /* V6N = 19 */
+	LCD_1IN14_V2_SendData_8Bit(0x2c); /* J0N = 2, V13N = 12 */
+	LCD_1IN14_V2_SendData_8Bit(0x3f); /* V20N = 63 */
+	LCD_1IN14_V2_SendData_8Bit(0x44); /* V36N = 4, V27N = 4 */
+	LCD_1IN14_V2_SendData_8Bit(0x51); /* V43N = 81 */
+	LCD_1IN14_V2_SendData_8Bit(0x2f); /* J1N = 2, V50N = 15 */
+	LCD_1IN14_V2_SendData_8Bit(0x1f); /* V57N = 31 */
+	LCD_1IN14_V2_SendData_8Bit(0x1f); /* V59N = 31 */
+	LCD_1IN14_V2_SendData_8Bit(0x20); /* V61N = 32 */
+	LCD_1IN14_V2_SendData_8Bit(0x23); /* V62N = 35 */
 
 	LCD_1IN14_V2_SendCommand(0x21); /* Display Inversion On */
 

--- a/memsim.c
+++ b/memsim.c
@@ -134,15 +134,17 @@ void check_disks(void)
 	int i, n = 0;
 
 	for (i = 0; i < 4; i++) {
-		/* try to open file */
-		sd_res = f_open(&sd_file, disks[i], FA_READ);
-		if (sd_res != FR_OK) {
-			printf("Disk image \"%s\" no longer exists.\n",
-			       disks[i]);
-			disks[i][0] = '\0';
-			n++;
-		} else
-			f_close(&sd_file);
+		if (disks[i][0]) {
+			/* try to open file */
+			sd_res = f_open(&sd_file, disks[i], FA_READ);
+			if (sd_res != FR_OK) {
+				printf("Disk image \"%s\" no longer exists.\n",
+				       disks[i]);
+				disks[i][0] = '\0';
+				n++;
+			} else
+				f_close(&sd_file);
+		}
 	}
 	if (n > 0)
 		putchar('\n');

--- a/memsim.c
+++ b/memsim.c
@@ -3,33 +3,19 @@
  *
  * Copyright (C) 2024 by Udo Munk
  *
- * This module implements the memory for the Z80/8080 CPU
- * and the low level access functions for MicroSD, needed
- * by the FDC.
+ * This module implements the memory for the Z80/8080 CPU.
  *
  * History:
  * 23-APR-2024 derived from z80sim
- * 27-MAY-2024 implemented load file
- * 28-MAY-2024 implemented sector I/O to disk images
- * 03-JUN-2024 added directory list for code files and disk images
  * 09-JUN-2024 implemented boot ROM
  * 28-JUN-2024 added second memory bank
  */
 
 #include <stdint.h>
 #include <stdlib.h>
-#include <stdio.h>
-#include <string.h>
-#include "f_util.h"
-#include "ff.h"
 #include "sim.h"
 #include "simglb.h"
 #include "memsim.h"
-#include "sd-fdc.h"
-
-extern FIL sd_file;
-extern FRESULT sd_res;
-extern char disks[4][22];
 
 /* 64KB bank 0 + common segment */
 unsigned char bnk0[65536];
@@ -39,9 +25,6 @@ unsigned char bnk1[49152];
 /* boot ROM code */
 #define MEMSIZE 256
 #include "bootrom.c"
-
-/* buffer for disk/memory transfers */
-static unsigned char dsk_buf[SEC_SZ];
 
 void init_memory(void)
 {
@@ -54,242 +37,6 @@ void init_memory(void)
 	/* trash memory like in a real machine after power on */
 	for (i = 0; i < 0xff00; i++)
 		bnk0[i] = rand() % 256;
-	for (i = 0; i < 49152; i++)
+	for (i = 0; i < 0xc000; i++)
 		bnk1[i] = rand() % 256;
-}
-
-/*
- * list files with pattern 'ext' in directory 'dir'
- */
-void list_files(const char *dir, const char *ext)
-{
-	DIR dp;
-	FILINFO fno;
-	FRESULT res;
-	register int i = 0;
-
-	res = f_findfirst(&dp, &fno, dir, ext);
-	if (res == FR_OK) {
-		while (1) {
-			printf("%s\t", fno.fname);
-			if (strlen(fno.fname) < 8)
-				putchar('\t');
-			i++;
-			if (i > 4) {
-				putchar('\n');
-				i = 0;
-			}
-			res = f_findnext(&dp, &fno);
-			if (!strlen(fno.fname)) {
-				if (i > 0)
-					putchar('\n');
-				break;
-			}
-		}
-	}
-}
-
-/*
- * load a file 'name' into memory
- */
-void load_file(char *name)
-{
-	int i = 0;
-	register unsigned int j;
-	unsigned int br;
-	char SFN[25];
-
-	strcpy(SFN, "/CODE80/");
-	strcat(SFN, name);
-	strcat(SFN, ".BIN");
-
-	/* try to open file */
-	sd_res = f_open(&sd_file, SFN, FA_READ);
-	if (sd_res != FR_OK) {
-		puts("File not found");
-		return;
-	}
-
-	/* read file into memory */
-	while ((sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br)) == FR_OK) {
-		for (j = 0; j < br; j++)
-			dma_write(i + j, dsk_buf[j]);
-		if (br < SEC_SZ)	/* last record reached */
-			break;
-		i += SEC_SZ;
-	}
-	if (sd_res != FR_OK)
-		printf("f_read error: %s (%d)\n", FRESULT_str(sd_res), sd_res);
-	else
-		printf("loaded file \"%s\" (%d bytes)\n", SFN, i + br);
-
-	f_close(&sd_file);
-}
-
-/*
- * check that all disks refer to existing files
- */
-void check_disks(void)
-{
-	int i, n = 0;
-
-	for (i = 0; i < 4; i++) {
-		if (disks[i][0]) {
-			/* try to open file */
-			sd_res = f_open(&sd_file, disks[i], FA_READ);
-			if (sd_res != FR_OK) {
-				printf("Disk image \"%s\" no longer exists.\n",
-				       disks[i]);
-				disks[i][0] = '\0';
-				n++;
-			} else
-				f_close(&sd_file);
-		}
-	}
-	if (n > 0)
-		putchar('\n');
-}
-
-/*
- * mount a disk image 'name' on disk 'drive'
- */
-void mount_disk(int drive, char *name)
-{
-	char SFN[22];
-	int i;
-
-	strcpy(SFN, "/DISKS80/");
-	strcat(SFN, name);
-	strcat(SFN, ".DSK");
-
-	for (i = 0; i < 4; i++) {
-		if (i != drive && strcmp(disks[i], SFN) == 0) {
-			puts("Disk already mounted\n");
-			return;
-		}
-	}
-
-	/* try to open file */
-	sd_res = f_open(&sd_file, SFN, FA_READ);
-	if (sd_res != FR_OK) {
-		puts("File not found\n");
-		return;
-	}
-
-	f_close(&sd_file);
-	strcpy(disks[drive], SFN);
-	putchar('\n');
-}
-
-/*
- * prepare I/O for sector read and write routines
- */
-static BYTE prep_io(int drive, int track, int sector, WORD addr)
-{
-	FSIZE_t pos;
-
-	/* check if drive in range */
-	if ((drive < 0) || (drive > 3))
-		return FDC_STAT_DISK;
-
-	/* check if track and sector in range */
-	if (track > TRK)
-		return FDC_STAT_TRACK;
-	if ((sector < 1) || (sector > SPT))
-		return FDC_STAT_SEC;
-
-	/* check if DMA address in range */
-	if (addr > 0xff7f)
-		return FDC_STAT_DMAADR;
-
-	/* check if disk in drive */
-	if (!strlen(disks[drive])) {
-		return FDC_STAT_NODISK;
-	}
-
-	/* open file with the disk image */
-	sd_res = f_open(&sd_file, disks[drive], FA_READ | FA_WRITE);
-	if (sd_res != FR_OK)
-		return FDC_STAT_NODISK;
-
-	/* seek to track/sector */
-	pos = (((FSIZE_t) track * (FSIZE_t) SPT) + sector - 1) * SEC_SZ;
-	if (f_lseek(&sd_file, pos) != FR_OK) {
-		f_close(&sd_file);
-		return FDC_STAT_SEEK;
-	}
-	return FDC_STAT_OK;
-}
-
-/*
- * read from drive a sector on track into memory @ addr
- */
-BYTE read_sec(int drive, int track, int sector, WORD addr)
-{
-	BYTE stat;
-	unsigned int br;
-	register int i;
-
-	/* prepare for sector read */
-	if ((stat = prep_io(drive, track, sector, addr)) != FDC_STAT_OK)
-		return stat;
-
-	/* read sector into memory */
-	sd_res = f_read(&sd_file, &dsk_buf[0], SEC_SZ, &br);
-	if (sd_res == FR_OK) {
-		if (br < SEC_SZ) {	/* UH OH */
-			f_close(&sd_file);
-			return FDC_STAT_READ;
-		} else {
-			f_close(&sd_file);
-			for (i = 0; i < SEC_SZ; i++)
-				dma_write(addr + i, dsk_buf[i]);
-			return FDC_STAT_OK;
-		}
-	} else {
-		f_close(&sd_file);
-		return FDC_STAT_READ;
-	}
-}
-
-/*
- * write to drive a sector on track from memory @ addr
- */
-BYTE write_sec(int drive, int track, int sector, WORD addr)
-{
-	BYTE stat;
-	unsigned int br;
-	register int i;
-
-	/* prepare for sector write */
-	if ((stat = prep_io(drive, track, sector, addr)) != FDC_STAT_OK)
-		return stat;
-
-	/* write sector to disk image */
-	for (i = 0; i < SEC_SZ; i++)
-		dsk_buf[i] = dma_read(addr + i);
-	sd_res = f_write(&sd_file, &dsk_buf[0], SEC_SZ, &br);
-	if (sd_res == FR_OK) {
-		if (br < SEC_SZ) {	/* UH OH */
-			f_close(&sd_file);
-			return FDC_STAT_WRITE;
-		} else {
-			f_close(&sd_file);
-			return FDC_STAT_OK;
-		}
-	} else {
-		f_close(&sd_file);
-		return FDC_STAT_WRITE;
-	}
-}
-
-/*
- * get FDC command from CPU memory
- */
-void get_fdccmd(BYTE *cmd, WORD addr)
-{
-	register int i;
-
-	for (i = 0; i < 4; i++)
-		cmd[i] = dma_read(addr + i);
 }

--- a/memsim.h
+++ b/memsim.h
@@ -3,7 +3,7 @@
  *
  * Copyright (C) 2024 by Udo Munk
  *
- * This module implements memory management for the Z80/8080 CPU
+ * This module implements memory management for the Z80/8080 CPU.
  *
  * History:
  * 23-APR-2024 derived from z80sim

--- a/picosim.c
+++ b/picosim.c
@@ -149,6 +149,8 @@ int main(void)
 
 	stdio_init_all();	/* initialize stdio */
 #if LIB_STDIO_MSC_USB
+	sd_init_driver();	/* initialize SD card driver */
+	tusb_init();		/* initialize TinyUSB */
 	stdio_msc_usb_init();	/* initialize MSC USB stdio */
 #endif
 	time_init();		/* initialize FatFS RTC */

--- a/picosim.c
+++ b/picosim.c
@@ -27,7 +27,6 @@
 #include "pico/stdlib.h"
 #include "pico/time.h"
 #include "hardware/adc.h"
-#include "f_util.h"
 #include "ff.h"
 #include "hw_config.h"
 #include "rtc.h"
@@ -37,82 +36,21 @@
 #include "simglb.h"
 #include "config.h"
 #include "memsim.h"
-#include "sd-fdc.h"
+#include "disks.h"
 #include "lcd.h"
 
 #define BS  0x08 /* backspace */
 #define DEL 0x7f /* delete */
-
-/* global variables for access to MicroSD card */
-
-/*
- * In the RP2024-GEEK the MicroSD card is connected to the MCU GPIO's
- * so that it either can be accessed with SPI or with SDIO. First it
- * was tested with SPI and then with SDIO, which is active because
- * data transfers are faster.
- */
-
-#if 0
-/* Configuration of RP2040 hardware SPI object */
-static spi_t spi = {
-	.hw_inst = spi0,  /* RP2040 SPI component */
-	.sck_gpio = 18,   /* GPIO number (not Pico pin number) */
-	.mosi_gpio = 19,
-	.miso_gpio = 20,
-	.baud_rate = 12 * 1000 * 1000 /* Actual frequency: 10416666 */
-};
-
-/* SPI Interface */
-static sd_spi_if_t spi_if = {
-	.spi = &spi,  /* Pointer to the SPI driving this card */
-	.ss_gpio = 23 /* The SPI slave select GPIO for this SD card */
-};
-
-/* Configuration of the SD Card socket object */
-static sd_card_t sd_card = {
-	.type = SD_IF_SPI,
-	.spi_if_p = &spi_if /* Pointer to the SPI interface driving this card */
-};
-#endif
-
-/* SDIO Interface */
-static sd_sdio_if_t sdio_if = {
-	.CMD_gpio = 19,
-	.D0_gpio = 20,
-	.baud_rate = 15 * 1000 * 1000 /* 15 MHz */
-};
-
-/* Configuration of the SD Card socket object */
-static sd_card_t sd_card = {
-	.type = SD_IF_SDIO,
-	.sdio_if_p = &sdio_if
-};
-
-FATFS fs;       /* FatFs on MicroSD */
-FIL sd_file;	/* at any time we have only one file open */
-FRESULT sd_res;	/* result code from FatFS */
-char disks[4][22]; /* path name for 4 disk images /DISKS80/filename.DSK */
 
 /* CPU speed */
 int speed = CPU_SPEED;
 
 extern void init_cpu(void), init_io(void), run_cpu(void);
 extern void report_cpu_error(void), report_cpu_stats(void);
+extern void init_disks(void), exit_disks(void);
 
 uint64_t get_clock_us(void);
 int get_cmdline(char *, int);
-
-/* Callbacks used by the SD library */
-size_t sd_get_num() { return 1; }
-
-sd_card_t *sd_get_by_num(size_t num)
-{
-	if (num == 0) {
-		return &sd_card;
-	} else {
-		return NULL;
-	}
-}
 
 #if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms)
@@ -177,12 +115,8 @@ int main(void)
 	printf("%s release %s\n", USR_COM, USR_REL);
 	printf("%s\n\n", USR_CPR);
 
-	/* try to mount SD card */
-	sd_res = f_mount(&fs, "", 1);
-	if (sd_res != FR_OK)
-		panic("f_mount error: %s (%d)\n", FRESULT_str(sd_res), sd_res);
-
 	init_cpu();		/* initialize CPU */
+	init_disks();		/* initialize disk drives */
 	init_memory();		/* initialize memory configuration */
 	init_io();		/* initialize I/O devices */
 	config();		/* configure the machine */
@@ -206,8 +140,8 @@ int main(void)
 	run_cpu();
 #endif
 
-	/* unmount SD card */
-	f_unmount("");
+	/* stop disk drives */
+	exit_disks();
 
 	/* shutdown LCD */
 	lcd_exit();

--- a/picosim.c
+++ b/picosim.c
@@ -121,30 +121,23 @@ int main(void)
 	init_io();		/* initialize I/O devices */
 	config();		/* configure the machine */
 
-	/* setup speed of the CPU */
-	f_flag = speed;
-	tmax = speed * 10000; /* theoretically */
+	f_flag = speed;		/* setup speed of the CPU */
+	tmax = speed * 10000;	/* theoretically */
 
-	/* power on jump into the boot ROM */
-	PC = 0xff00;
+	PC = 0xff00;		/* power on jump into the boot ROM */
 
-	/* tell LCD refresh task to display default infos */
-	lcd_default_draw_func();
+	lcd_default_draw_func(); /* tell LCD task to display default infos */
 
-	/* run the CPU with whatever is in memory */
 #ifdef WANT_ICE
 	extern void ice_cmd_loop(int);
 
 	ice_cmd_loop(0);
 #else
-	run_cpu();
+	run_cpu();		/* run the CPU with whatever is in memory */
 #endif
 
-	/* stop disk drives */
-	exit_disks();
-
-	/* shutdown LCD */
-	lcd_exit();
+	exit_disks();		/* stop disk drives */
+	lcd_exit();		/* shutdown LCD */
 
 #ifndef WANT_ICE
 	putchar('\n');

--- a/picosim.c
+++ b/picosim.c
@@ -21,7 +21,7 @@
 /* Raspberry SDK and FatFS includes */
 #include <stdio.h>
 #include <string.h>
-#if LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 #include <tusb.h>
 #endif
 #include "pico/stdlib.h"
@@ -114,7 +114,7 @@ sd_card_t *sd_get_by_num(size_t num)
 	}
 }
 
-#if LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 void tud_cdc_send_break_cb(uint8_t itf, uint16_t duration_ms)
 {
 	UNUSED(itf);
@@ -148,6 +148,9 @@ int main(void)
 	char s[2];
 
 	stdio_init_all();	/* initialize stdio */
+#if LIB_STDIO_MSC_USB
+	stdio_msc_usb_init();	/* initialize MSC USB stdio */
+#endif
 	time_init();		/* initialize FatFS RTC */
 	lcd_init();		/* initialize LCD */
 
@@ -160,7 +163,7 @@ int main(void)
 	adc_select_input(4);
 
 	/* when using USB UART wait until it is connected */
-#if LIB_PICO_STDIO_USB
+#if LIB_PICO_STDIO_USB || LIB_STDIO_MSC_USB
 	lcd_set_draw_func(draw_wait_term);
 	while (!tud_cdc_connected())
 		sleep_ms(100);

--- a/picosim.c
+++ b/picosim.c
@@ -130,8 +130,8 @@ static void __not_in_flash_func(draw_wait_term)(int first_flag)
 	if (!first_flag)
 		return;
 	Paint_Clear(BLACK);
-	Paint_DrawString(32, 35, "Waiting for", &Font32, RED, BLACK);
-	Paint_DrawString(32, 67, "  terminal ", &Font32, RED, BLACK);
+	Paint_DrawString(43, 39, "Waiting for", &Font28, RED, BLACK);
+	Paint_DrawString(43, 67, "  terminal ", &Font28, RED, BLACK);
 }
 
 static void __not_in_flash_func(draw_banner)(int first_flag)
@@ -139,8 +139,8 @@ static void __not_in_flash_func(draw_banner)(int first_flag)
 	if (!first_flag)
 		return;
 	Paint_Clear(BLACK);
-	Paint_DrawString(32, 35, "# Z80pack #", &Font32, BLACK, WHITE);
-	Paint_DrawString(32, 67, "RP2040-GEEK", &Font32, BLACK, WHITE);
+	Paint_DrawString(43, 39, "# Z80pack #", &Font28, BLACK, WHITE);
+	Paint_DrawString(43, 67, "RP2040-GEEK", &Font28, BLACK, WHITE);
 }
 
 int main(void)

--- a/stdio_msc_usb/CMakeLists.txt
+++ b/stdio_msc_usb/CMakeLists.txt
@@ -1,0 +1,27 @@
+if (TARGET tinyusb_device_unmarked)
+    pico_add_library(stdio_msc_usb)
+
+    target_include_directories(stdio_msc_usb_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+
+    target_sources(stdio_msc_usb INTERFACE
+        ${CMAKE_CURRENT_LIST_DIR}/reset_interface.c
+        ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb.c
+        ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb_descriptors.c
+    )
+
+    pico_mirrored_target_link_libraries(stdio_msc_usb INTERFACE
+        pico_stdio
+        pico_time
+        pico_unique_id
+        pico_usb_reset_interface
+    )
+    target_link_libraries(stdio_msc_usb INTERFACE
+        tinyusb_device_unmarked
+    )
+    # PICO_CMAKE_CONFIG: PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=pico_stdio_usb
+    if (PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS)
+        target_compile_definitions(stdio_msc_usb INTERFACE
+            PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=${PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS}
+        )
+    endif()
+endif()

--- a/stdio_msc_usb/CMakeLists.txt
+++ b/stdio_msc_usb/CMakeLists.txt
@@ -1,27 +1,26 @@
-if (TARGET tinyusb_device_unmarked)
-    pico_add_library(stdio_msc_usb)
+pico_add_library(stdio_msc_usb)
 
-    target_include_directories(stdio_msc_usb_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
+target_include_directories(stdio_msc_usb_headers INTERFACE ${CMAKE_CURRENT_LIST_DIR}/include)
 
-    target_sources(stdio_msc_usb INTERFACE
-        ${CMAKE_CURRENT_LIST_DIR}/reset_interface.c
-        ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb.c
-        ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb_descriptors.c
-    )
+target_sources(stdio_msc_usb INTERFACE
+    ${CMAKE_CURRENT_LIST_DIR}/msc_usb.c
+    ${CMAKE_CURRENT_LIST_DIR}/reset_interface.c
+    ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb.c
+    ${CMAKE_CURRENT_LIST_DIR}/stdio_msc_usb_descriptors.c
+)
 
-    pico_mirrored_target_link_libraries(stdio_msc_usb INTERFACE
-        pico_stdio
-        pico_time
-        pico_unique_id
-        pico_usb_reset_interface
+pico_mirrored_target_link_libraries(stdio_msc_usb INTERFACE
+    pico_stdio
+    pico_time
+    pico_unique_id
+    pico_usb_reset_interface
+)
+target_link_libraries(stdio_msc_usb INTERFACE
+    tinyusb_device
+)
+# PICO_CMAKE_CONFIG: STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=stdio_msc_usb
+if (STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS)
+    target_compile_definitions(stdio_msc_usb INTERFACE
+        STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS=${STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS}
     )
-    target_link_libraries(stdio_msc_usb INTERFACE
-        tinyusb_device_unmarked
-    )
-    # PICO_CMAKE_CONFIG: PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=pico_stdio_usb
-    if (PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS)
-        target_compile_definitions(stdio_msc_usb INTERFACE
-            PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS=${PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS}
-        )
-    endif()
 endif()

--- a/stdio_msc_usb/include/stdio_msc_usb.h
+++ b/stdio_msc_usb/include/stdio_msc_usb.h
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef _STDIO_MSC_USB_H
+#define _STDIO_MSC_USB_H
+
+#include "pico/stdio.h"
+
+/** \brief Support for stdin/stdout over USB serial (CDC)
+ *  \defgroup pico_stdio_usb pico_stdio_usb
+ *  \ingroup pico_stdio
+ *
+ *  Linking this library or calling `pico_enable_stdio_usb(TARGET ENABLED)` in the CMake (which
+ *  achieves the same thing) will add USB CDC to the drivers used for standard input/output
+ *
+ *  Note this library is a developer convenience. It is not applicable in all cases; for one it takes full control of the USB device precluding your
+ *  use of the USB in device or host mode. For this reason, this library will automatically disengage if you try to using it alongside \ref tinyusb_device or
+ *  \ref tinyusb_host. It also takes control of a lower level IRQ and sets up a periodic background task.
+ *
+ *  This library also includes (by default) functionality to enable the RP2040 to be reset over the USB interface.
+ */
+
+// PICO_CONFIG: PICO_STDIO_USB_DEFAULT_CRLF, Default state of CR/LF translation for USB output, type=bool, default=PICO_STDIO_DEFAULT_CRLF, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_DEFAULT_CRLF
+#define PICO_STDIO_USB_DEFAULT_CRLF PICO_STDIO_DEFAULT_CRLF
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_STDOUT_TIMEOUT_US, Number of microseconds to be blocked trying to write USB output before assuming the host has disappeared and discarding data, default=500000, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_STDOUT_TIMEOUT_US
+#define PICO_STDIO_USB_STDOUT_TIMEOUT_US 500000
+#endif
+
+// todo perhaps unnecessarily frequent?
+// PICO_CONFIG: PICO_STDIO_USB_TASK_INTERVAL_US, Period of microseconds between calling tud_task in the background, default=1000, advanced=true, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_TASK_INTERVAL_US
+#define PICO_STDIO_USB_TASK_INTERVAL_US 1000
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_LOW_PRIORITY_IRQ, Explicit User IRQ number to claim for tud_task() background execution instead of letting the implementation pick a free one dynamically (deprecated), advanced=true, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+// this variable is no longer set by default (one is claimed dynamically), but will be respected if specified
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE, Enable/disable resetting into BOOTSEL mode if the host sets the baud rate to a magic value (PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE), type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE
+#define PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE 1
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE
+#define PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE 1200
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS
+#define PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS 0
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS, Number of extra milliseconds to wait when using PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS after a host CDC connection is detected (some host terminals seem to sometimes lose transmissions sent right after connection), default=50, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS
+#define PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS 50
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=29, group=pico_stdio_usb
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
+#define PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED 0
+#endif
+
+// Any modes disabled here can't be re-enabled by picotool via VENDOR_INTERFACE.
+// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, Optionally disable either the mass storage interface (bit 0) or the PICOBOOT interface (bit 1) when entering BOOTSEL mode via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=3, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK
+#define PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK 0u
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE, Enable/disable resetting into BOOTSEL mode via an additional VENDOR USB interface - enables picotool based reset, type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+#define PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE 1
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL, If vendor reset interface is included allow rebooting to BOOTSEL mode, type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
+#define PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL 1
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT, If vendor reset interface is included allow rebooting with regular flash boot, type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
+#define PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT 1
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS, delays in ms before rebooting via regular flash boot, default=100, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS
+#define PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS 100
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_CONNECTION_WITHOUT_DTR, Disable use of DTR for connection checking meaning connection is assumed to be valid, type=bool, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_CONNECTION_WITHOUT_DTR
+#define PICO_STDIO_USB_CONNECTION_WITHOUT_DTR 0
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_DEVICE_SELF_POWERED, Set USB device as self powered device, type=bool, default=0, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_DEVICE_SELF_POWERED
+#define PICO_STDIO_USB_DEVICE_SELF_POWERED 0
+#endif
+
+// PICO_CONFIG: PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable USB STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of USB CDC RX callback elsewhere, type=bool, default=1, group=pico_stdio_usb
+#ifndef PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+#define PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK 1
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+extern stdio_driver_t stdio_msc_usb;
+
+/*! \brief Explicitly initialize USB stdio and add it to the current set of stdin drivers
+ *  \ingroup pico_stdio_usb
+ *
+ *  \ref PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS can be set to cause this method to wait for a CDC connection
+ *  from the host before returning, which is useful if you don't want any initial stdout output to be discarded
+ *  before the connection is established.
+ *
+ *  \return true if the USB CDC was initialized, false if an error occurred
+ */
+bool stdio_msc_usb_init(void);
+
+/*! \brief Check if there is an active stdio CDC connection to a host
+ *  \ingroup pico_stdio_usb
+ *
+ *  \return true if stdio is connected over CDC
+ */
+bool stdio_msc_usb_connected(void);
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/stdio_msc_usb/include/stdio_msc_usb.h
+++ b/stdio_msc_usb/include/stdio_msc_usb.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2024 Thomas Eberhardt
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
@@ -10,106 +11,103 @@
 #include "pico/stdio.h"
 
 /** \brief Support for stdin/stdout over USB serial (CDC)
- *  \defgroup pico_stdio_usb pico_stdio_usb
+ *  \defgroup stdio_msc_usb stdio_msc_usb
  *  \ingroup pico_stdio
  *
- *  Linking this library or calling `pico_enable_stdio_usb(TARGET ENABLED)` in the CMake (which
- *  achieves the same thing) will add USB CDC to the drivers used for standard input/output
+ *  Linking this library in the CMake will add USB CDC to the drivers used for standard input/output
  *
- *  Note this library is a developer convenience. It is not applicable in all cases; for one it takes full control of the USB device precluding your
- *  use of the USB in device or host mode. For this reason, this library will automatically disengage if you try to using it alongside \ref tinyusb_device or
- *  \ref tinyusb_host. It also takes control of a lower level IRQ and sets up a periodic background task.
+ *  It takes control of a lower level IRQ and sets up a periodic background task.
  *
  *  This library also includes (by default) functionality to enable the RP2040 to be reset over the USB interface.
  */
 
-// PICO_CONFIG: PICO_STDIO_USB_DEFAULT_CRLF, Default state of CR/LF translation for USB output, type=bool, default=PICO_STDIO_DEFAULT_CRLF, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_DEFAULT_CRLF
-#define PICO_STDIO_USB_DEFAULT_CRLF PICO_STDIO_DEFAULT_CRLF
+// PICO_CONFIG: STDIO_MSC_USB_DEFAULT_CRLF, Default state of CR/LF translation for USB output, type=bool, default=PICO_STDIO_DEFAULT_CRLF, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_DEFAULT_CRLF
+#define STDIO_MSC_USB_DEFAULT_CRLF PICO_STDIO_DEFAULT_CRLF
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_STDOUT_TIMEOUT_US, Number of microseconds to be blocked trying to write USB output before assuming the host has disappeared and discarding data, default=500000, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_STDOUT_TIMEOUT_US
-#define PICO_STDIO_USB_STDOUT_TIMEOUT_US 500000
+// PICO_CONFIG: STDIO_MSC_USB_STDOUT_TIMEOUT_US, Number of microseconds to be blocked trying to write USB output before assuming the host has disappeared and discarding data, default=500000, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_STDOUT_TIMEOUT_US
+#define STDIO_MSC_USB_STDOUT_TIMEOUT_US 500000
 #endif
 
 // todo perhaps unnecessarily frequent?
-// PICO_CONFIG: PICO_STDIO_USB_TASK_INTERVAL_US, Period of microseconds between calling tud_task in the background, default=1000, advanced=true, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_TASK_INTERVAL_US
-#define PICO_STDIO_USB_TASK_INTERVAL_US 1000
+// PICO_CONFIG: STDIO_MSC_USB_TASK_INTERVAL_US, Period of microseconds between calling tud_task in the background, default=1000, advanced=true, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_TASK_INTERVAL_US
+#define STDIO_MSC_USB_TASK_INTERVAL_US 1000
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_LOW_PRIORITY_IRQ, Explicit User IRQ number to claim for tud_task() background execution instead of letting the implementation pick a free one dynamically (deprecated), advanced=true, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+// PICO_CONFIG: STDIO_MSC_USB_LOW_PRIORITY_IRQ, Explicit User IRQ number to claim for tud_task() background execution instead of letting the implementation pick a free one dynamically (deprecated), advanced=true, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_LOW_PRIORITY_IRQ
 // this variable is no longer set by default (one is claimed dynamically), but will be respected if specified
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE, Enable/disable resetting into BOOTSEL mode if the host sets the baud rate to a magic value (PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE), type=bool, default=1, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE
-#define PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE 1
+// PICO_CONFIG: STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE, Enable/disable resetting into BOOTSEL mode if the host sets the baud rate to a magic value (STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE), type=bool, default=1, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE
+#define STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE 1
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE
-#define PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE 1200
+// PICO_CONFIG: STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE, baud rate that if selected causes a reset into BOOTSEL mode (if STDIO_MSC_USB_ENABLE_RESET_VIA_BAUD_RATE is set), default=1200, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE
+#define STDIO_MSC_USB_RESET_MAGIC_BAUD_RATE 1200
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS
-#define PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS 0
+// PICO_CONFIG: STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS, Maximum number of milliseconds to wait during initialization for a CDC connection from the host (negative means indefinite) during initialization, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS
+#define STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS 0
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS, Number of extra milliseconds to wait when using PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS after a host CDC connection is detected (some host terminals seem to sometimes lose transmissions sent right after connection), default=50, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS
-#define PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS 50
+// PICO_CONFIG: STDIO_MSC_USB_POST_CONNECT_WAIT_DELAY_MS, Number of extra milliseconds to wait when using STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS after a host CDC connection is detected (some host terminals seem to sometimes lose transmissions sent right after connection), default=50, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_POST_CONNECT_WAIT_DELAY_MS
+#define STDIO_MSC_USB_POST_CONNECT_WAIT_DELAY_MS 50
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=29, group=pico_stdio_usb
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED, Optionally define a pin to use as bootloader activity LED when BOOTSEL mode is entered via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=29, group=stdio_msc_usb
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
-#define PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED 0
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED, Whether the pin specified by STDIO_MSC_USB_RESET_BOOTSEL_ACTIVITY_LED is fixed or can be modified by picotool over the VENDOR USB interface, type=bool, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
+#define STDIO_MSC_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED 0
 #endif
 
 // Any modes disabled here can't be re-enabled by picotool via VENDOR_INTERFACE.
-// PICO_CONFIG: PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, Optionally disable either the mass storage interface (bit 0) or the PICOBOOT interface (bit 1) when entering BOOTSEL mode via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=3, default=0, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK
-#define PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK 0u
+// PICO_CONFIG: STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK, Optionally disable either the mass storage interface (bit 0) or the PICOBOOT interface (bit 1) when entering BOOTSEL mode via USB (either VIA_BAUD_RATE or VIA_VENDOR_INTERFACE), type=int, min=0, max=3, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK
+#define STDIO_MSC_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK 0u
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE, Enable/disable resetting into BOOTSEL mode via an additional VENDOR USB interface - enables picotool based reset, type=bool, default=1, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
-#define PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE 1
+// PICO_CONFIG: STDIO_MSC_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE, Enable/disable resetting into BOOTSEL mode via an additional VENDOR USB interface - enables picotool based reset, type=bool, default=1, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+#define STDIO_MSC_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE 1
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL, If vendor reset interface is included allow rebooting to BOOTSEL mode, type=bool, default=1, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
-#define PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL 1
+// PICO_CONFIG: STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL, If vendor reset interface is included allow rebooting to BOOTSEL mode, type=bool, default=1, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
+#define STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL 1
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT, If vendor reset interface is included allow rebooting with regular flash boot, type=bool, default=1, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
-#define PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT 1
+// PICO_CONFIG: STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT, If vendor reset interface is included allow rebooting with regular flash boot, type=bool, default=1, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
+#define STDIO_MSC_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT 1
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS, delays in ms before rebooting via regular flash boot, default=100, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS
-#define PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS 100
+// PICO_CONFIG: STDIO_MSC_USB_RESET_RESET_TO_FLASH_DELAY_MS, delays in ms before rebooting via regular flash boot, default=100, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_RESET_RESET_TO_FLASH_DELAY_MS
+#define STDIO_MSC_USB_RESET_RESET_TO_FLASH_DELAY_MS 100
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_CONNECTION_WITHOUT_DTR, Disable use of DTR for connection checking meaning connection is assumed to be valid, type=bool, default=0, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_CONNECTION_WITHOUT_DTR
-#define PICO_STDIO_USB_CONNECTION_WITHOUT_DTR 0
+// PICO_CONFIG: STDIO_MSC_USB_CONNECTION_WITHOUT_DTR, Disable use of DTR for connection checking meaning connection is assumed to be valid, type=bool, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_CONNECTION_WITHOUT_DTR
+#define STDIO_MSC_USB_CONNECTION_WITHOUT_DTR 0
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_DEVICE_SELF_POWERED, Set USB device as self powered device, type=bool, default=0, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_DEVICE_SELF_POWERED
-#define PICO_STDIO_USB_DEVICE_SELF_POWERED 0
+// PICO_CONFIG: STDIO_MSC_USB_DEVICE_SELF_POWERED, Set USB device as self powered device, type=bool, default=0, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_DEVICE_SELF_POWERED
+#define STDIO_MSC_USB_DEVICE_SELF_POWERED 0
 #endif
 
-// PICO_CONFIG: PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable USB STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of USB CDC RX callback elsewhere, type=bool, default=1, group=pico_stdio_usb
-#ifndef PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
-#define PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK 1
+// PICO_CONFIG: STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK, Enable USB STDIO support for stdio_set_chars_available_callback. Can be disabled to make use of USB CDC RX callback elsewhere, type=bool, default=1, group=stdio_msc_usb
+#ifndef STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+#define STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK 1
 #endif
 
 #ifdef __cplusplus
@@ -119,9 +117,9 @@ extern "C" {
 extern stdio_driver_t stdio_msc_usb;
 
 /*! \brief Explicitly initialize USB stdio and add it to the current set of stdin drivers
- *  \ingroup pico_stdio_usb
+ *  \ingroup stdio_msc_usb
  *
- *  \ref PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS can be set to cause this method to wait for a CDC connection
+ *  \ref STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS can be set to cause this method to wait for a CDC connection
  *  from the host before returning, which is useful if you don't want any initial stdout output to be discarded
  *  before the connection is established.
  *
@@ -130,7 +128,7 @@ extern stdio_driver_t stdio_msc_usb;
 bool stdio_msc_usb_init(void);
 
 /*! \brief Check if there is an active stdio CDC connection to a host
- *  \ingroup pico_stdio_usb
+ *  \ingroup stdio_msc_usb
  *
  *  \return true if stdio is connected over CDC
  */

--- a/stdio_msc_usb/include/tusb_config.h
+++ b/stdio_msc_usb/include/tusb_config.h
@@ -3,6 +3,7 @@
  *
  * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
  * Copyright (c) 2020 Damien P. George
+ * Copyright (c) 2024 Thomas Eberhardt
  *
  * Permission is hereby granted, free of charge, to any person obtaining a copy
  * of this software and associated documentation files (the "Software"), to deal
@@ -29,15 +30,16 @@
 
 #include "stdio_msc_usb.h"
 
-#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
 #define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
 
 #define CFG_TUD_CDC             (1)
 #define CFG_TUD_CDC_RX_BUFSIZE  (256)
 #define CFG_TUD_CDC_TX_BUFSIZE  (256)
 
+#define CFG_TUD_MSC             (1)
+#define CFG_TUD_MSC_EP_BUFSIZE  (4096)
+
 // We use a vendor specific interface but with our own driver
 #define CFG_TUD_VENDOR            (0)
-#endif
 
 #endif

--- a/stdio_msc_usb/include/tusb_config.h
+++ b/stdio_msc_usb/include/tusb_config.h
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2020 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#ifndef _STDIO_MSC_USB_TUSB_CONFIG_H
+#define _STDIO_MSC_USB_TUSB_CONFIG_H
+
+#include "stdio_msc_usb.h"
+
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+#define CFG_TUSB_RHPORT0_MODE   (OPT_MODE_DEVICE)
+
+#define CFG_TUD_CDC             (1)
+#define CFG_TUD_CDC_RX_BUFSIZE  (256)
+#define CFG_TUD_CDC_TX_BUFSIZE  (256)
+
+// We use a vendor specific interface but with our own driver
+#define CFG_TUD_VENDOR            (0)
+#endif
+
+#endif

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -1,0 +1,211 @@
+/* 
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ * Copyright (c) 2024 Thomas Eberhardt
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#include "tusb.h"
+#include "hw_config.h"
+#include "sd_card.h"
+
+// whether mass storage interface is active
+bool msc_ejected = true;
+
+// Invoked when received SCSI_CMD_INQUIRY
+// Application fill vendor id, product id and revision with string up
+// to 8, 16, 4 characters respectively
+void tud_msc_inquiry_cb(uint8_t lun, uint8_t vendor_id[8],
+			uint8_t product_id[16], uint8_t product_rev[4])
+{
+	(void) lun;
+
+	const char vid[] = "Z80pack";
+	const char pid[] = "Mass Storage";
+	const char rev[] = "1.0";
+
+	memcpy(vendor_id, vid, strlen(vid));
+	memcpy(product_id, pid, strlen(pid));
+	memcpy(product_rev, rev, strlen(rev));
+}
+
+// Invoked when received Test Unit Ready command.
+// return true allowing host to read/write this LUN e.g SD card inserted
+bool tud_msc_test_unit_ready_cb(uint8_t lun)
+{
+	(void) lun;
+
+	if (msc_ejected) {
+		// Additional Sense 3A-00 is NOT_FOUND
+		tud_msc_set_sense(lun, SCSI_SENSE_NOT_READY, 0x3a, 0x00);
+		return false;
+	}
+
+	return true;
+}
+
+// Invoked when received SCSI_CMD_READ_CAPACITY_10 and
+// SCSI_CMD_READ_FORMAT_CAPACITY to determine the disk size
+// Application update block count and block size
+void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count,
+			 uint16_t* block_size)
+{
+	sd_card_t *sd_card_p = sd_get_by_num(0);
+
+	(void) lun;
+
+	if (sd_card_p == NULL) {
+		*block_count = 0;
+		*block_size = 0;
+	} else {
+		*block_count = sd_card_p->get_num_sectors(sd_card_p);
+		*block_size = 512;
+	}
+}
+
+// Invoked when received Start Stop Unit command
+// - Start = 0 : stopped power mode, if load_eject = 1 : unload disk storage
+// - Start = 1 : active mode, if load_eject = 1 : load disk storage
+bool tud_msc_start_stop_cb(uint8_t lun, uint8_t power_condition, bool start,
+			   bool load_eject)
+{
+	(void) lun;
+	(void) power_condition;
+
+	if (load_eject) {
+		if (start) {
+			// load disk storage
+		} else {
+			// unload disk storage
+			msc_ejected = true;
+		}
+	}
+
+	return true;
+}
+
+// Callback invoked when received READ10 command.
+// Copy disk's data to buffer (up to bufsize) and return number of
+// copied bytes.
+int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
+			  void* buffer, uint32_t bufsize)
+{
+	sd_card_t *sd_card_p = sd_get_by_num(0);
+	uint32_t blockcnt;
+	block_dev_err_t rc;
+
+	(void) lun;
+	(void) offset;
+
+	if (sd_card_p == NULL)
+		return -1;
+
+	if (lba >= sd_card_p->get_num_sectors(sd_card_p))
+		return -1;
+
+	blockcnt = bufsize / 512;
+
+	rc = sd_card_p->read_blocks(sd_card_p, buffer, lba, blockcnt);
+	if (rc != SD_BLOCK_DEVICE_ERROR_NONE)
+		return -1;
+	else
+		return blockcnt * 512;
+}
+
+bool tud_msc_is_writable_cb (uint8_t lun)
+{
+	(void) lun;
+
+	return sd_get_by_num(0) != NULL;
+}
+
+// Callback invoked when received WRITE10 command.
+// Process data in buffer to disk's storage and return number of written bytes.
+int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
+			   uint8_t* buffer, uint32_t bufsize)
+{
+	sd_card_t *sd_card_p = sd_get_by_num(0);
+	uint32_t blockcnt;
+	block_dev_err_t rc;
+
+	(void) lun;
+	(void) offset;
+
+	if (sd_card_p == NULL)
+		return -1;
+
+	if (lba >= sd_card_p->get_num_sectors(sd_card_p))
+		return -1;
+
+	blockcnt = bufsize / 512;
+
+	rc = sd_card_p->write_blocks(sd_card_p, buffer, lba, blockcnt);
+	if (rc != SD_BLOCK_DEVICE_ERROR_NONE)
+		return -1;
+	else
+		return blockcnt * 512;
+}
+
+// Callback invoked when received an SCSI command not in built-in list below
+// - READ_CAPACITY10, READ_FORMAT_CAPACITY, INQUIRY, MODE_SENSE6, REQUEST_SENSE
+// - READ10 and WRITE10 has their own callbacks
+int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
+			 void* buffer, uint16_t bufsize)
+{
+	// read10 & write10 has their own callback and MUST not be handled here
+
+	void const* response = NULL;
+	int32_t resplen = 0;
+
+	// most scsi handled is input
+	bool in_xfer = true;
+
+	switch (scsi_cmd[0]) {
+	case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
+		// always successful
+		resplen = 0;
+		break;
+
+	default:
+		// Set Sense = Invalid Command Operation
+		tud_msc_set_sense(lun, SCSI_SENSE_ILLEGAL_REQUEST, 0x20, 0x00);
+
+		// negative means error -> tinyusb could stall and/or response
+		// with failed status
+		resplen = -1;
+		break;
+	}
+
+	// return resplen must not larger than bufsize
+	if (resplen > bufsize)
+		resplen = bufsize;
+
+	if (response && (resplen > 0)) {
+		if (in_xfer) {
+			memcpy(buffer, response, (size_t) resplen);
+		} else {
+			// SCSI output
+		}
+	}
+
+	return (int32_t) resplen;
+}

--- a/stdio_msc_usb/reset_interface.c
+++ b/stdio_msc_usb/reset_interface.c
@@ -1,0 +1,115 @@
+/**
+ * Copyright (c) 2021 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+#include "tusb.h"
+
+#include "pico/bootrom.h"
+
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+
+#if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE && !(PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL || PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT)
+#warning PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE has been selected but neither PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL nor PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT have been selected.
+#endif
+
+#if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+#include "pico/usb_reset_interface.h"
+#include "hardware/watchdog.h"
+#include "device/usbd_pvt.h"
+
+static uint8_t itf_num;
+
+static void resetd_init(void) {
+}
+
+static void resetd_reset(uint8_t __unused rhport) {
+    itf_num = 0;
+}
+
+static uint16_t resetd_open(uint8_t __unused rhport, tusb_desc_interface_t const *itf_desc, uint16_t max_len) {
+    TU_VERIFY(TUSB_CLASS_VENDOR_SPECIFIC == itf_desc->bInterfaceClass &&
+              RESET_INTERFACE_SUBCLASS == itf_desc->bInterfaceSubClass &&
+              RESET_INTERFACE_PROTOCOL == itf_desc->bInterfaceProtocol, 0);
+
+    uint16_t const drv_len = sizeof(tusb_desc_interface_t);
+    TU_VERIFY(max_len >= drv_len, 0);
+
+    itf_num = itf_desc->bInterfaceNumber;
+    return drv_len;
+}
+
+// Support for parameterized reset via vendor interface control request
+static bool resetd_control_xfer_cb(uint8_t __unused rhport, uint8_t stage, tusb_control_request_t const * request) {
+    // nothing to do with DATA & ACK stage
+    if (stage != CONTROL_STAGE_SETUP) return true;
+
+    if (request->wIndex == itf_num) {
+
+#if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_BOOTSEL
+        if (request->bRequest == RESET_REQUEST_BOOTSEL) {
+#ifdef PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED
+            uint gpio_mask = 1u << PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED;
+#else
+            uint gpio_mask = 0u;
+#endif
+#if !PICO_STDIO_USB_RESET_BOOTSEL_FIXED_ACTIVITY_LED
+            if (request->wValue & 0x100) {
+                gpio_mask = 1u << (request->wValue >> 9u);
+            }
+#endif
+            reset_usb_boot(gpio_mask, (request->wValue & 0x7f) | PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+            // does not return, otherwise we'd return true
+        }
+#endif
+
+#if PICO_STDIO_USB_RESET_INTERFACE_SUPPORT_RESET_TO_FLASH_BOOT
+        if (request->bRequest == RESET_REQUEST_FLASH) {
+            watchdog_reboot(0, 0, PICO_STDIO_USB_RESET_RESET_TO_FLASH_DELAY_MS);
+            return true;
+        }
+#endif
+
+    }
+    return false;
+}
+
+static bool resetd_xfer_cb(uint8_t __unused rhport, uint8_t __unused ep_addr, xfer_result_t __unused result, uint32_t __unused xferred_bytes) {
+    return true;
+}
+
+static usbd_class_driver_t const _resetd_driver =
+{
+#if CFG_TUSB_DEBUG >= 2
+    .name = "RESET",
+#endif
+    .init             = resetd_init,
+    .reset            = resetd_reset,
+    .open             = resetd_open,
+    .control_xfer_cb  = resetd_control_xfer_cb,
+    .xfer_cb          = resetd_xfer_cb,
+    .sof              = NULL
+};
+
+// Implement callback to add our custom driver
+usbd_class_driver_t const *usbd_app_driver_get_cb(uint8_t *driver_count) {
+    *driver_count = 1;
+    return &_resetd_driver;
+}
+#endif
+
+#if PICO_STDIO_USB_ENABLE_RESET_VIA_BAUD_RATE
+// Support for default BOOTSEL reset by changing baud rate
+void tud_cdc_line_coding_cb(__unused uint8_t itf, cdc_line_coding_t const* p_line_coding) {
+    if (p_line_coding->bit_rate == PICO_STDIO_USB_RESET_MAGIC_BAUD_RATE) {
+#ifdef PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED
+        const uint gpio_mask = 1u << PICO_STDIO_USB_RESET_BOOTSEL_ACTIVITY_LED;
+#else
+        const uint gpio_mask = 0u;
+#endif
+        reset_usb_boot(gpio_mask, PICO_STDIO_USB_RESET_BOOTSEL_INTERFACE_DISABLE_MASK);
+    }
+}
+#endif
+
+#endif

--- a/stdio_msc_usb/stdio_msc_usb.c
+++ b/stdio_msc_usb/stdio_msc_usb.c
@@ -1,16 +1,12 @@
 /**
  * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2024 Thomas Eberhardt
  *
  * SPDX-License-Identifier: BSD-3-Clause
  */
 
-#ifndef LIB_TINYUSB_HOST
 #include "tusb.h"
 #include "stdio_msc_usb.h"
-
-// these may not be set if the user is providing tud support (i.e. LIB_TINYUSB_DEVICE is 1 because
-// the user linked in tinyusb_device) but they haven't selected CDC
-#if (CFG_TUD_ENABLED | TUSB_OPT_DEVICE_ENABLED) && CFG_TUD_CDC
 
 #include "pico/binary_info.h"
 #include "pico/time.h"
@@ -21,21 +17,19 @@
 
 static mutex_t stdio_msc_usb_mutex;
 
-#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+#if STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
 static void (*chars_available_callback)(void*);
 static void *chars_available_param;
 #endif
 
-// when tinyusb_device is explicitly linked we do no background tud processing
-#if !LIB_TINYUSB_DEVICE
 // if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
 // we don't either create multiple one shot timers, or miss creating one. this crit_sec
 // is used to protect the one_shot_timer_pending flag
 static critical_section_t one_shot_timer_crit_sec;
 static volatile bool one_shot_timer_pending;
-#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
-static_assert(PICO_STDIO_USB_LOW_PRIORITY_IRQ >= NUM_IRQS - NUM_USER_IRQS, "");
-#define low_priority_irq_num PICO_STDIO_USB_LOW_PRIORITY_IRQ
+#ifdef STDIO_MSC_USB_LOW_PRIORITY_IRQ
+static_assert(STDIO_MSC_USB_LOW_PRIORITY_IRQ >= NUM_IRQS - NUM_USER_IRQS, "");
+#define low_priority_irq_num STDIO_MSC_USB_LOW_PRIORITY_IRQ
 #else
 static uint8_t low_priority_irq_num;
 #endif
@@ -48,7 +42,7 @@ static int64_t timer_task(__unused alarm_id_t id, __unused void *user_data) {
         critical_section_exit(&one_shot_timer_crit_sec);
         repeat_time = 0; // don't repeat
     } else {
-        repeat_time = PICO_STDIO_USB_TASK_INTERVAL_US;
+        repeat_time = STDIO_MSC_USB_TASK_INTERVAL_US;
     }
     irq_set_pending(low_priority_irq_num);
     return repeat_time;
@@ -76,7 +70,7 @@ static void low_priority_worker_irq(void) {
             one_shot_timer_pending = true;
             critical_section_exit(&one_shot_timer_crit_sec);
             if (need_timer) {
-                add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true);
+                add_alarm_in_us(STDIO_MSC_USB_TASK_INTERVAL_US, timer_task, NULL, true);
             }
         }
     }
@@ -85,8 +79,6 @@ static void low_priority_worker_irq(void) {
 static void usb_irq(void) {
     irq_set_pending(low_priority_irq_num);
 }
-
-#endif
 
 static void stdio_msc_usb_out_chars(const char *buf, int length) {
     static uint64_t last_avail_time;
@@ -108,7 +100,7 @@ static void stdio_msc_usb_out_chars(const char *buf, int length) {
                 tud_task();
                 tud_cdc_write_flush();
                 if (!stdio_msc_usb_connected() ||
-                    (!tud_cdc_write_available() && time_us_64() > last_avail_time + PICO_STDIO_USB_STDOUT_TIMEOUT_US)) {
+                    (!tud_cdc_write_available() && time_us_64() > last_avail_time + STDIO_MSC_USB_STDOUT_TIMEOUT_US)) {
                     break;
                 }
             }
@@ -146,7 +138,7 @@ int stdio_msc_usb_in_chars(char *buf, int length) {
     return rc;
 }
 
-#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+#if STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
 void tud_cdc_rx_cb(__unused uint8_t itf) {
     if (chars_available_callback) {
         usbd_defer_func(chars_available_callback, chars_available_param, false);
@@ -162,11 +154,11 @@ void stdio_msc_usb_set_chars_available_callback(void (*fn)(void*), void *param) 
 stdio_driver_t stdio_msc_usb = {
     .out_chars = stdio_msc_usb_out_chars,
     .in_chars = stdio_msc_usb_in_chars,
-#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+#if STDIO_MSC_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
     .set_chars_available_callback = stdio_msc_usb_set_chars_available_callback,
 #endif
 #if PICO_STDIO_ENABLE_CRLF_SUPPORT
-    .crlf_enabled = PICO_STDIO_USB_DEFAULT_CRLF
+    .crlf_enabled = STDIO_MSC_USB_DEFAULT_CRLF
 #endif
 
 };
@@ -182,18 +174,10 @@ bool stdio_msc_usb_init(void) {
     bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));
 #endif
 
-#if !defined(LIB_TINYUSB_DEVICE)
-    // initialize TinyUSB, as user hasn't explicitly linked it
-    tusb_init();
-#else
-    assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
-#endif
-
     mutex_init(&stdio_msc_usb_mutex);
     bool rc = true;
-#if !LIB_TINYUSB_DEVICE
-#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
-    user_irq_claim(PICO_STDIO_USB_LOW_PRIORITY_IRQ);
+#ifdef STDIO_MSC_USB_LOW_PRIORITY_IRQ
+    user_irq_claim(STDIO_MSC_USB_LOW_PRIORITY_IRQ);
 #else
     low_priority_irq_num = (uint8_t) user_irq_claim_unused(true);
 #endif
@@ -205,23 +189,22 @@ bool stdio_msc_usb_init(void) {
         irq_add_shared_handler(USBCTRL_IRQ, usb_irq, PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY);
         critical_section_init_with_lock_num(&one_shot_timer_crit_sec, next_striped_spin_lock_num());
     } else {
-        rc = add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true) >= 0;
+        rc = add_alarm_in_us(STDIO_MSC_USB_TASK_INTERVAL_US, timer_task, NULL, true) >= 0;
         // we use initialization state of the one_shot_timer_critsec as a flag
         memset(&one_shot_timer_crit_sec, 0, sizeof(one_shot_timer_crit_sec));
     }
-#endif
     if (rc) {
         stdio_set_driver_enabled(&stdio_msc_usb, true);
-#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS
-#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS > 0
-        absolute_time_t until = make_timeout_time_ms(PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS);
+#if STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS
+#if STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS > 0
+        absolute_time_t until = make_timeout_time_ms(STDIO_MSC_USB_CONNECT_WAIT_TIMEOUT_MS);
 #else
         absolute_time_t until = at_the_end_of_time;
 #endif
         do {
             if (stdio_msc_usb_connected()) {
-#if PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS != 0
-                sleep_ms(PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS);
+#if STDIO_MSC_USB_POST_CONNECT_WAIT_DELAY_MS != 0
+                sleep_ms(STDIO_MSC_USB_POST_CONNECT_WAIT_DELAY_MS);
 #endif
                 break;
             }
@@ -233,24 +216,10 @@ bool stdio_msc_usb_init(void) {
 }
 
 bool stdio_msc_usb_connected(void) {
-#if PICO_STDIO_USB_CONNECTION_WITHOUT_DTR
+#if STDIO_MSC_USB_CONNECTION_WITHOUT_DTR
     return tud_ready();
 #else
     // this actually checks DTR
     return tud_cdc_connected();
 #endif
 }
-
-#else
-#warning stdio USB was configured along with user use of TinyUSB device mode, but CDC is not enabled
-bool stdio_msc_usb_init(void) {
-    return false;
-}
-#endif // CFG_TUD_ENABLED && CFG_TUD_CDC
-#else
-#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
-bool stdio_msc_usb_init(void) {
-    return false;
-}
-#endif // !LIB_TINYUSB_HOST
-

--- a/stdio_msc_usb/stdio_msc_usb.c
+++ b/stdio_msc_usb/stdio_msc_usb.c
@@ -1,0 +1,256 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#ifndef LIB_TINYUSB_HOST
+#include "tusb.h"
+#include "stdio_msc_usb.h"
+
+// these may not be set if the user is providing tud support (i.e. LIB_TINYUSB_DEVICE is 1 because
+// the user linked in tinyusb_device) but they haven't selected CDC
+#if (CFG_TUD_ENABLED | TUSB_OPT_DEVICE_ENABLED) && CFG_TUD_CDC
+
+#include "pico/binary_info.h"
+#include "pico/time.h"
+#include "pico/stdio/driver.h"
+#include "pico/mutex.h"
+#include "hardware/irq.h"
+#include "device/usbd_pvt.h" // for usbd_defer_func
+
+static mutex_t stdio_msc_usb_mutex;
+
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+static void (*chars_available_callback)(void*);
+static void *chars_available_param;
+#endif
+
+// when tinyusb_device is explicitly linked we do no background tud processing
+#if !LIB_TINYUSB_DEVICE
+// if this crit_sec is initialized, we are not in periodic timer mode, and must make sure
+// we don't either create multiple one shot timers, or miss creating one. this crit_sec
+// is used to protect the one_shot_timer_pending flag
+static critical_section_t one_shot_timer_crit_sec;
+static volatile bool one_shot_timer_pending;
+#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+static_assert(PICO_STDIO_USB_LOW_PRIORITY_IRQ >= NUM_IRQS - NUM_USER_IRQS, "");
+#define low_priority_irq_num PICO_STDIO_USB_LOW_PRIORITY_IRQ
+#else
+static uint8_t low_priority_irq_num;
+#endif
+
+static int64_t timer_task(__unused alarm_id_t id, __unused void *user_data) {
+    int64_t repeat_time;
+    if (critical_section_is_initialized(&one_shot_timer_crit_sec)) {
+        critical_section_enter_blocking(&one_shot_timer_crit_sec);
+        one_shot_timer_pending = false;
+        critical_section_exit(&one_shot_timer_crit_sec);
+        repeat_time = 0; // don't repeat
+    } else {
+        repeat_time = PICO_STDIO_USB_TASK_INTERVAL_US;
+    }
+    irq_set_pending(low_priority_irq_num);
+    return repeat_time;
+}
+
+static void low_priority_worker_irq(void) {
+    if (mutex_try_enter(&stdio_msc_usb_mutex, NULL)) {
+        tud_task();
+        mutex_exit(&stdio_msc_usb_mutex);
+    } else {
+        // if the mutex is already owned, then we are in non IRQ code in this file.
+        //
+        // it would seem simplest to just let that code call tud_task() at the end, however this
+        // code might run during the call to tud_task() and we might miss a necessary tud_task() call
+        //
+        // if we are using a periodic timer (crit_sec is not initialized in this case),
+        // then we are happy just to wait until the next tick, however when we are not using a periodic timer,
+        // we must kick off a one-shot timer to make sure the tud_task() DOES run (this method
+        // will be called again as a result, and will try the mutex_try_enter again, and if that fails
+        // create another one shot timer again, and so on).
+        if (critical_section_is_initialized(&one_shot_timer_crit_sec)) {
+            bool need_timer;
+            critical_section_enter_blocking(&one_shot_timer_crit_sec);
+            need_timer = !one_shot_timer_pending;
+            one_shot_timer_pending = true;
+            critical_section_exit(&one_shot_timer_crit_sec);
+            if (need_timer) {
+                add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true);
+            }
+        }
+    }
+}
+
+static void usb_irq(void) {
+    irq_set_pending(low_priority_irq_num);
+}
+
+#endif
+
+static void stdio_msc_usb_out_chars(const char *buf, int length) {
+    static uint64_t last_avail_time;
+    if (!mutex_try_enter_block_until(&stdio_msc_usb_mutex, make_timeout_time_ms(PICO_STDIO_DEADLOCK_TIMEOUT_MS))) {
+        return;
+    }
+    if (stdio_msc_usb_connected()) {
+        for (int i = 0; i < length;) {
+            int n = length - i;
+            int avail = (int) tud_cdc_write_available();
+            if (n > avail) n = avail;
+            if (n) {
+                int n2 = (int) tud_cdc_write(buf + i, (uint32_t)n);
+                tud_task();
+                tud_cdc_write_flush();
+                i += n2;
+                last_avail_time = time_us_64();
+            } else {
+                tud_task();
+                tud_cdc_write_flush();
+                if (!stdio_msc_usb_connected() ||
+                    (!tud_cdc_write_available() && time_us_64() > last_avail_time + PICO_STDIO_USB_STDOUT_TIMEOUT_US)) {
+                    break;
+                }
+            }
+        }
+    } else {
+        // reset our timeout
+        last_avail_time = 0;
+    }
+    mutex_exit(&stdio_msc_usb_mutex);
+}
+
+int stdio_msc_usb_in_chars(char *buf, int length) {
+    // note we perform this check outside the lock, to try and prevent possible deadlock conditions
+    // with printf in IRQs (which we will escape through timeouts elsewhere, but that would be less graceful).
+    //
+    // these are just checks of state, so we can call them while not holding the lock.
+    // they may be wrong, but only if we are in the middle of a tud_task call, in which case at worst
+    // we will mistakenly think we have data available when we do not (we will check again), or
+    // tud_task will complete running and we will check the right values the next time.
+    //
+    int rc = PICO_ERROR_NO_DATA;
+    if (stdio_msc_usb_connected() && tud_cdc_available()) {
+        if (!mutex_try_enter_block_until(&stdio_msc_usb_mutex, make_timeout_time_ms(PICO_STDIO_DEADLOCK_TIMEOUT_MS))) {
+            return PICO_ERROR_NO_DATA; // would deadlock otherwise
+        }
+        if (stdio_msc_usb_connected() && tud_cdc_available()) {
+            int count = (int) tud_cdc_read(buf, (uint32_t) length);
+            rc = count ? count : PICO_ERROR_NO_DATA;
+        } else {
+            // because our mutex use may starve out the background task, run tud_task here (we own the mutex)
+            tud_task();
+        }
+        mutex_exit(&stdio_msc_usb_mutex);
+    }
+    return rc;
+}
+
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+void tud_cdc_rx_cb(__unused uint8_t itf) {
+    if (chars_available_callback) {
+        usbd_defer_func(chars_available_callback, chars_available_param, false);
+    }
+}
+
+void stdio_msc_usb_set_chars_available_callback(void (*fn)(void*), void *param) {
+    chars_available_callback = fn;
+    chars_available_param = param;
+}
+#endif
+
+stdio_driver_t stdio_msc_usb = {
+    .out_chars = stdio_msc_usb_out_chars,
+    .in_chars = stdio_msc_usb_in_chars,
+#if PICO_STDIO_USB_SUPPORT_CHARS_AVAILABLE_CALLBACK
+    .set_chars_available_callback = stdio_msc_usb_set_chars_available_callback,
+#endif
+#if PICO_STDIO_ENABLE_CRLF_SUPPORT
+    .crlf_enabled = PICO_STDIO_USB_DEFAULT_CRLF
+#endif
+
+};
+
+bool stdio_msc_usb_init(void) {
+    if (get_core_num() != alarm_pool_core_num(alarm_pool_get_default())) {
+        // included an assertion here rather than just returning false, as this is likely
+        // a coding bug, rather than anything else.
+        assert(false);
+        return false;
+    }
+#if !PICO_NO_BI_STDIO_USB
+    bi_decl_if_func_used(bi_program_feature("USB stdin / stdout"));
+#endif
+
+#if !defined(LIB_TINYUSB_DEVICE)
+    // initialize TinyUSB, as user hasn't explicitly linked it
+    tusb_init();
+#else
+    assert(tud_inited()); // we expect the caller to have initialized if they are using TinyUSB
+#endif
+
+    mutex_init(&stdio_msc_usb_mutex);
+    bool rc = true;
+#if !LIB_TINYUSB_DEVICE
+#ifdef PICO_STDIO_USB_LOW_PRIORITY_IRQ
+    user_irq_claim(PICO_STDIO_USB_LOW_PRIORITY_IRQ);
+#else
+    low_priority_irq_num = (uint8_t) user_irq_claim_unused(true);
+#endif
+    irq_set_exclusive_handler(low_priority_irq_num, low_priority_worker_irq);
+    irq_set_enabled(low_priority_irq_num, true);
+
+    if (irq_has_shared_handler(USBCTRL_IRQ)) {
+        // we can use a shared handler to notice when there may be work to do
+        irq_add_shared_handler(USBCTRL_IRQ, usb_irq, PICO_SHARED_IRQ_HANDLER_LOWEST_ORDER_PRIORITY);
+        critical_section_init_with_lock_num(&one_shot_timer_crit_sec, next_striped_spin_lock_num());
+    } else {
+        rc = add_alarm_in_us(PICO_STDIO_USB_TASK_INTERVAL_US, timer_task, NULL, true) >= 0;
+        // we use initialization state of the one_shot_timer_critsec as a flag
+        memset(&one_shot_timer_crit_sec, 0, sizeof(one_shot_timer_crit_sec));
+    }
+#endif
+    if (rc) {
+        stdio_set_driver_enabled(&stdio_msc_usb, true);
+#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS
+#if PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS > 0
+        absolute_time_t until = make_timeout_time_ms(PICO_STDIO_USB_CONNECT_WAIT_TIMEOUT_MS);
+#else
+        absolute_time_t until = at_the_end_of_time;
+#endif
+        do {
+            if (stdio_msc_usb_connected()) {
+#if PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS != 0
+                sleep_ms(PICO_STDIO_USB_POST_CONNECT_WAIT_DELAY_MS);
+#endif
+                break;
+            }
+            sleep_ms(10);
+        } while (!time_reached(until));
+#endif
+    }
+    return rc;
+}
+
+bool stdio_msc_usb_connected(void) {
+#if PICO_STDIO_USB_CONNECTION_WITHOUT_DTR
+    return tud_ready();
+#else
+    // this actually checks DTR
+    return tud_cdc_connected();
+#endif
+}
+
+#else
+#warning stdio USB was configured along with user use of TinyUSB device mode, but CDC is not enabled
+bool stdio_msc_usb_init(void) {
+    return false;
+}
+#endif // CFG_TUD_ENABLED && CFG_TUD_CDC
+#else
+#warning stdio USB was configured, but is being disabled as TinyUSB host is explicitly linked
+bool stdio_msc_usb_init(void) {
+    return false;
+}
+#endif // !LIB_TINYUSB_HOST
+

--- a/stdio_msc_usb/stdio_msc_usb_descriptors.c
+++ b/stdio_msc_usb/stdio_msc_usb_descriptors.c
@@ -1,0 +1,176 @@
+/*
+ * This file is based on a file originally part of the
+ * MicroPython project, http://micropython.org/
+ *
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ * Copyright (c) 2019 Damien P. George
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+#if !defined(LIB_TINYUSB_HOST) && !defined(LIB_TINYUSB_DEVICE)
+
+#include "tusb.h"
+#include "pico/usb_reset_interface.h"
+#include "pico/unique_id.h"
+
+#ifndef USBD_VID
+#define USBD_VID (0x2E8A) // Raspberry Pi
+#endif
+
+#ifndef USBD_PID
+#define USBD_PID (0x000a) // Raspberry Pi Pico SDK CDC
+#endif
+
+#ifndef USBD_MANUFACTURER
+#define USBD_MANUFACTURER "Raspberry Pi"
+#endif
+
+#ifndef USBD_PRODUCT
+#define USBD_PRODUCT "Pico"
+#endif
+
+#define TUD_RPI_RESET_DESC_LEN  9
+#if !PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+#define USBD_DESC_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN)
+#else
+#define USBD_DESC_LEN (TUD_CONFIG_DESC_LEN + TUD_CDC_DESC_LEN + TUD_RPI_RESET_DESC_LEN)
+#endif
+#if !PICO_STDIO_USB_DEVICE_SELF_POWERED
+#define USBD_CONFIGURATION_DESCRIPTOR_ATTRIBUTE (0)
+#define USBD_MAX_POWER_MA (250)
+#else
+#define USBD_CONFIGURATION_DESCRIPTOR_ATTRIBUTE TUSB_DESC_CONFIG_ATT_SELF_POWERED
+#define USBD_MAX_POWER_MA (1)
+#endif
+
+#define USBD_ITF_CDC       (0) // needs 2 interfaces
+#if !PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+#define USBD_ITF_MAX       (2)
+#else
+#define USBD_ITF_RPI_RESET (2)
+#define USBD_ITF_MAX       (3)
+#endif
+
+#define USBD_CDC_EP_CMD (0x81)
+#define USBD_CDC_EP_OUT (0x02)
+#define USBD_CDC_EP_IN (0x82)
+#define USBD_CDC_CMD_MAX_SIZE (8)
+#define USBD_CDC_IN_OUT_MAX_SIZE (64)
+
+#define USBD_STR_0 (0x00)
+#define USBD_STR_MANUF (0x01)
+#define USBD_STR_PRODUCT (0x02)
+#define USBD_STR_SERIAL (0x03)
+#define USBD_STR_CDC (0x04)
+#define USBD_STR_RPI_RESET (0x05)
+
+// Note: descriptors returned from callbacks must exist long enough for transfer to complete
+
+static const tusb_desc_device_t usbd_desc_device = {
+    .bLength = sizeof(tusb_desc_device_t),
+    .bDescriptorType = TUSB_DESC_DEVICE,
+    .bcdUSB = 0x0200,
+    .bDeviceClass = TUSB_CLASS_MISC,
+    .bDeviceSubClass = MISC_SUBCLASS_COMMON,
+    .bDeviceProtocol = MISC_PROTOCOL_IAD,
+    .bMaxPacketSize0 = CFG_TUD_ENDPOINT0_SIZE,
+    .idVendor = USBD_VID,
+    .idProduct = USBD_PID,
+    .bcdDevice = 0x0100,
+    .iManufacturer = USBD_STR_MANUF,
+    .iProduct = USBD_STR_PRODUCT,
+    .iSerialNumber = USBD_STR_SERIAL,
+    .bNumConfigurations = 1,
+};
+
+#define TUD_RPI_RESET_DESCRIPTOR(_itfnum, _stridx) \
+  /* Interface */\
+  9, TUSB_DESC_INTERFACE, _itfnum, 0, 0, TUSB_CLASS_VENDOR_SPECIFIC, RESET_INTERFACE_SUBCLASS, RESET_INTERFACE_PROTOCOL, _stridx,
+
+static const uint8_t usbd_desc_cfg[USBD_DESC_LEN] = {
+    TUD_CONFIG_DESCRIPTOR(1, USBD_ITF_MAX, USBD_STR_0, USBD_DESC_LEN,
+        USBD_CONFIGURATION_DESCRIPTOR_ATTRIBUTE, USBD_MAX_POWER_MA),
+
+    TUD_CDC_DESCRIPTOR(USBD_ITF_CDC, USBD_STR_CDC, USBD_CDC_EP_CMD,
+        USBD_CDC_CMD_MAX_SIZE, USBD_CDC_EP_OUT, USBD_CDC_EP_IN, USBD_CDC_IN_OUT_MAX_SIZE),
+
+#if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+    TUD_RPI_RESET_DESCRIPTOR(USBD_ITF_RPI_RESET, USBD_STR_RPI_RESET)
+#endif
+};
+
+static char usbd_serial_str[PICO_UNIQUE_BOARD_ID_SIZE_BYTES * 2 + 1];
+
+static const char *const usbd_desc_str[] = {
+    [USBD_STR_MANUF] = USBD_MANUFACTURER,
+    [USBD_STR_PRODUCT] = USBD_PRODUCT,
+    [USBD_STR_SERIAL] = usbd_serial_str,
+    [USBD_STR_CDC] = "Board CDC",
+#if PICO_STDIO_USB_ENABLE_RESET_VIA_VENDOR_INTERFACE
+    [USBD_STR_RPI_RESET] = "Reset",
+#endif
+};
+
+const uint8_t *tud_descriptor_device_cb(void) {
+    return (const uint8_t *)&usbd_desc_device;
+}
+
+const uint8_t *tud_descriptor_configuration_cb(__unused uint8_t index) {
+    return usbd_desc_cfg;
+}
+
+const uint16_t *tud_descriptor_string_cb(uint8_t index, __unused uint16_t langid) {
+#ifndef USBD_DESC_STR_MAX
+#define USBD_DESC_STR_MAX (20)
+#elif USBD_DESC_STR_MAX > 127
+#error USBD_DESC_STR_MAX too high (max is 127).
+#elif USBD_DESC_STR_MAX < 17
+#error USBD_DESC_STR_MAX too low (min is 17).
+#endif
+    static uint16_t desc_str[USBD_DESC_STR_MAX];
+
+    // Assign the SN using the unique flash id
+    if (!usbd_serial_str[0]) {
+        pico_get_unique_board_id_string(usbd_serial_str, sizeof(usbd_serial_str));
+    }
+
+    uint8_t len;
+    if (index == 0) {
+        desc_str[1] = 0x0409; // supported language is English
+        len = 1;
+    } else {
+        if (index >= sizeof(usbd_desc_str) / sizeof(usbd_desc_str[0])) {
+            return NULL;
+        }
+        const char *str = usbd_desc_str[index];
+        for (len = 0; len < USBD_DESC_STR_MAX - 1 && str[len]; ++len) {
+            desc_str[1 + len] = str[len];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    desc_str[0] = (uint16_t) ((TUSB_DESC_STRING << 8) | (2 * len + 2));
+
+    return desc_str;
+}
+
+#endif


### PR DESCRIPTION
You can now mount the SD card on the host with the 'u' command from the config menu. Only tested on Linux. Won't win any speed prices, but totally usable for copying IBM 8-inch floppy disk images.

Clean-up LCD driver comments.

Make local copy of pico_stdio_usb, rename it to stdio_msc_usb, and use it.

Rename all PICO_STDIO_USB symbols to STDIO_MSC_USB. Explicitly link tinyusb_device library and remove all LIB_TINYUSB_HOST and LIB_TINYUSB_DEVICE conditionals from stdio_msc_usb.

Add USB mass storage code based on pico-sdk/lib/tinyusb/examples/device/cdc_msc. Only thing I needed to add was adding SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL handling to allow "Eject" to work (at least on Linux).
    
Since this adds a new interface to the USB descriptor I needed to change the VID/PID. I used the test device 1209/0001 from https://pid.codes .

Or we could buy an official USB vendor ID for $6000...