### PR TITLE
make mass storage USB code easy to turn off and turn it off for now

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,12 +72,6 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	LCD_COLOR_DEPTH=12
 	# LCD refresh rate in Hz (30 works well with 12-bit frame buffer)
 	LCD_REFRESH=30
-	# USB vendor and product id's.
-	# This is the pid.codes private testing VID/PID, this is not
-	# universally unique and should not be used outside test environments.
-	# See https://pid.codes/1209/1001
-	USBD_VID=0x1209
-	USBD_PID=0x0001
 )
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE
@@ -102,8 +96,8 @@ target_link_libraries(${PROJECT_NAME}
 	hardware_spi
 	pico_multicore
 	pico_stdlib
-	stdio_msc_usb
-	tinyusb_device
+#	stdio_msc_usb
+#	tinyusb_device
 	no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
 	Config
 	Fonts
@@ -122,4 +116,4 @@ pico_set_program_url(${PROJECT_NAME} "https://github.com/udo-munk/RP2040-GEEK-80
 
 # disable UART in/out, enable USB in/out
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
-# pico_enable_stdio_usb(${PROJECT_NAME} 1)
+pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/config.c
+++ b/config.c
@@ -33,7 +33,9 @@ extern FRESULT sd_res;
 extern char disks[NUMDISK][DISKLEN];
 extern int speed;
 extern BYTE fp_value;
+#if LIB_STDIO_MSC_USB
 extern int msc_ejected;
+#endif
 
 extern int get_cmdline(char *, int);
 extern void switch_cpu(int);
@@ -126,7 +128,9 @@ void config(void)
 		printf("m - rotate LCD\n");
 		printf("a - set date\n");
 		printf("t - set time\n");
+#if LIB_STDIO_MSC_USB
 		printf("u - enable USB mass storage access\n");
+#endif
 		printf("c - switch CPU, currently %s\n",
 		       (cpu == Z80) ? "Z80" : "8080");
 		printf("s - CPU speed: %d MHz\n", speed);
@@ -203,6 +207,7 @@ void config(void)
 			putchar('\n');
 			break;
 
+#if LIB_STDIO_MSC_USB
 		case 'u':
 			exit_disks();
 			puts("Waiting for disk to be ejected");
@@ -213,6 +218,7 @@ void config(void)
 			init_disks();
 			check_disks();
 			break;
+#endif
 
 		case 'c':
 			if (cpu == Z80)

--- a/stdio_msc_usb/stdio_msc_usb_descriptors.c
+++ b/stdio_msc_usb/stdio_msc_usb_descriptors.c
@@ -31,12 +31,19 @@
 #include "pico/usb_reset_interface.h"
 #include "pico/unique_id.h"
 
+/*
+ * USB vendor and product id's.
+ * This is the pid.codes private testing VID/PID, this is not
+ * universally unique and should not be used outside test environments.
+ * See https://pid.codes/1209/1001 .
+ */
+
 #ifndef USBD_VID
-#error Please define a USB vendor id as USBD_VID
+#define USBD_VID (0x1209)
 #endif
 
 #ifndef USBD_PID
-#error Please define a USB product id as USBD_PID
+#define USBD_PID (0x0001)
 #endif
 
 #ifndef USBD_MANUFACTURER


### PR DESCRIPTION
To turn it back on enable the "stdio_msc_usb" and "tinyusb_device" libraries and comment out "pico_enable_stdio_usb(${PROJECT_NAME} 1)".