### PR TITLE
Fix (hopefully) USB mass storage on Windows and config menu tweaks

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -96,8 +96,8 @@ target_link_libraries(${PROJECT_NAME}
 	hardware_spi
 	pico_multicore
 	pico_stdlib
-#	stdio_msc_usb
-#	tinyusb_device
+	stdio_msc_usb
+	tinyusb_device
 	no-OS-FatFS-SD-SDIO-SPI-RPi-Pico
 	Config
 	Fonts
@@ -116,4 +116,4 @@ pico_set_program_url(${PROJECT_NAME} "https://github.com/udo-munk/RP2040-GEEK-80
 
 # disable UART in/out, enable USB in/out
 pico_enable_stdio_uart(${PROJECT_NAME} 0)
-pico_enable_stdio_usb(${PROJECT_NAME} 1)
+#pico_enable_stdio_usb(${PROJECT_NAME} 1)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -72,6 +72,11 @@ target_compile_definitions(${PROJECT_NAME} PRIVATE
 	LCD_COLOR_DEPTH=12
 	# LCD refresh rate in Hz (30 works well with 12-bit frame buffer)
 	LCD_REFRESH=30
+	# This is the pid.codes private testing USB VID/PID. This is not
+	# universally unique and should not be used outside test environments.
+	# See https://pid.codes/1209/1001 .
+	USBD_VID=0x1209
+	USBD_PID=0x0001
 )
 
 target_compile_definitions(${PROJECT_NAME} INTERFACE

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # z80pack on RP2040-GEEK
 
+__NOTICE__: The USB vendor and product ID's used (1209/0001) are the
+ones reserved by [pid.codes](https://pid.codes) for private
+testing. These are not universally unique, and should not be used
+outside test environments. Please change them in CMakeLists.txt, if
+you intend any other usage.
+
 While looking arround for RP2040 based systems that can easily be
 used by non technical users, I found this:
 

--- a/picosim.c
+++ b/picosim.c
@@ -157,14 +157,16 @@ uint64_t get_clock_us(void)
 }
 
 /*
- * read an ICE or config command line from the terminal
+ * Read an ICE or config command line of maximum length len - 1
+ * from the terminal. For single character requests (len == 2),
+ * returns immediately after input is received.
  */
 int get_cmdline(char *buf, int len)
 {
 	int i = 0;
 	char c;
 
-	while (i < len - 1) {
+	for (;;) {
 		c = getchar();
 		if ((c == BS) || (c == DEL)) {
 			if (i >= 1) {
@@ -174,13 +176,17 @@ int get_cmdline(char *buf, int len)
 				i--;
 			}
 		} else if (c != '\r') {
-			buf[i++] = c;
-			putchar(c);
+			if (i < len - 1) {
+				buf[i++] = c;
+				putchar(c);
+				if (len == 2)
+					break;
+			}
 		} else {
 			break;
 		}
 	}
-	buf[i++] = '\0';
+	buf[i] = '\0';
 	putchar('\n');
 	return 0;
 }

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -29,8 +29,8 @@
 #include "sd_card.h"
 
 typedef enum {
-	SCSI_CMD_VERIFY			= 0x2f,
-	SCSI_CMD_SYNCHRONIZE_CACHE	= 0x35
+	SCSI_CMD_VERIFY_10		= 0x2f,
+	SCSI_CMD_SYNCHRONIZE_CACHE_10	= 0x35
 } scsi_cmd_type_2_t;
 
 // whether mass storage interface is active
@@ -195,11 +195,11 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 			resplen = -1;	// any prevents unsupported
 		break;
 
-	case SCSI_CMD_VERIFY:
+	case SCSI_CMD_VERIFY_10:
 		resplen = 0;		// report success
 		break;
 
-	case SCSI_CMD_SYNCHRONIZE_CACHE:
+	case SCSI_CMD_SYNCHRONIZE_CACHE_10:
 		resplen = 0;		// report success
 		break;
 

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -73,7 +73,7 @@ void tud_msc_capacity_cb(uint8_t lun, uint32_t* block_count,
 
 	(void) lun;
 
-	if (sd_card_p == NULL) {
+	if (sd_card_p == NULL || msc_ejected) {
 		*block_count = 0;
 		*block_size = 0;
 	} else {
@@ -116,7 +116,7 @@ int32_t tud_msc_read10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
 	(void) lun;
 	(void) offset;
 
-	if (sd_card_p == NULL)
+	if (sd_card_p == NULL || msc_ejected)
 		return -1;
 
 	if (lba >= sd_card_p->get_num_sectors(sd_card_p))
@@ -150,7 +150,7 @@ int32_t tud_msc_write10_cb(uint8_t lun, uint32_t lba, uint32_t offset,
 	(void) lun;
 	(void) offset;
 
-	if (sd_card_p == NULL)
+	if (sd_card_p == NULL || msc_ejected)
 		return -1;
 
 	if (lba >= sd_card_p->get_num_sectors(sd_card_p))

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -181,8 +181,16 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 
 	switch (scsi_cmd[0]) {
 	case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-		// always successful
-		resplen = 0;
+		scsi_prevent_allow_medium_removal_t const *prevent_allow =
+		  (scsi_prevent_allow_medium_removal_t const *) scsi_cmd;
+
+		if ((prevent_allow->prohibit_removal & 3) == 0) {
+			// allow
+			resplen = 0;
+		} else {
+			// any prevents unsupported
+			resplen = -1;
+		}
 		break;
 
 	default:

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -182,7 +182,7 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 	switch (scsi_cmd[0]) {
 	case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
 		scsi_prevent_allow_medium_removal_t const *prevent_allow =
-		  (scsi_prevent_allow_medium_removal_t const *) scsi_cmd;
+			(scsi_prevent_allow_medium_removal_t const *) scsi_cmd;
 
 		if ((prevent_allow->prohibit_removal & 3) == 0) {
 			// allow

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -28,6 +28,11 @@
 #include "hw_config.h"
 #include "sd_card.h"
 
+typedef enum {
+	SCSI_CMD_VERIFY			= 0x2f,
+	SCSI_CMD_SYNCHRONIZE_CACHE	= 0x35
+} scsi_cmd_type_2_t;
+
 // whether mass storage interface is active
 bool msc_ejected = true;
 
@@ -184,13 +189,18 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 		scsi_prevent_allow_medium_removal_t const *prevent_allow =
 			(scsi_prevent_allow_medium_removal_t const *) scsi_cmd;
 
-		if ((prevent_allow->prohibit_removal & 3) == 0) {
-			// allow
-			resplen = 0;
-		} else {
-			// any prevents unsupported
-			resplen = -1;
-		}
+		if ((prevent_allow->prohibit_removal & 3) == 0)
+			resplen = 0;	// allow succeeds
+		else
+			resplen = -1;	// any prevents unsupported
+		break;
+
+	case SCSI_CMD_VERIFY:
+		resplen = 0;		// report success
+		break;
+
+	case SCSI_CMD_SYNCHRONIZE_CACHE:
+		resplen = 0;		// report success
 		break;
 
 	default:

--- a/stdio_msc_usb/stdio_msc_usb_descriptors.c
+++ b/stdio_msc_usb/stdio_msc_usb_descriptors.c
@@ -31,19 +31,12 @@
 #include "pico/usb_reset_interface.h"
 #include "pico/unique_id.h"
 
-/*
- * USB vendor and product id's.
- * This is the pid.codes private testing VID/PID, this is not
- * universally unique and should not be used outside test environments.
- * See https://pid.codes/1209/1001 .
- */
-
 #ifndef USBD_VID
-#define USBD_VID (0x1209)
+#error Please define a USB vendor id as USBD_VID
 #endif
 
 #ifndef USBD_PID
-#define USBD_PID (0x0001)
+#error Please define a USB product id as USBD_PID
 #endif
 
 #ifndef USBD_MANUFACTURER


### PR DESCRIPTION
I used Wireshark with an USB packet sniffer to look at what happened.

Windows 11 was going bonkers after sending READ_FORMAT_CAPACITY and I returned the full card size when it was in the ejected state.

It now works in my Windows 11 VM.

Still, not very user friendly behavior from Windows when a badly behaving device is attached.

Also changed PREVENT_ALLOW  to fail on all prevent requests, so that Windows doesn't succeed in
preventing media removal and starts to cache any transfers.