### PR TITLE
just disable the irq tud_task call, and succeed on all prevent/allow cmds

### DIFF
--- a/stdio_msc_usb/include/stdio_msc_usb.h
+++ b/stdio_msc_usb/include/stdio_msc_usb.h
@@ -142,9 +142,9 @@ bool stdio_msc_usb_init(void);
  */
 bool stdio_msc_usb_connected(void);
 
-bool stdio_msc_usb_disable_stdio(void);
+void stdio_msc_usb_enable_irq_tud_task(void);
 
-void stdio_msc_usb_enable_stdio(void);
+void stdio_msc_usb_disable_irq_tud_task(void);
 
 void stdio_msc_usb_do_msc(void);
 

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -196,14 +196,7 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 
 	switch (scsi_cmd[0]) {
 	case SCSI_CMD_PREVENT_ALLOW_MEDIUM_REMOVAL:
-		{
-			scsi_prevent_allow_medium_removal_t const *
-				prevent_allow =
-				(scsi_prevent_allow_medium_removal_t const *)
-				scsi_cmd;
-
-			resplen = 0;		// report success
-		}
+		resplen = 0;			// report success
 		break;
 
 	case SCSI_CMD_VERIFY_10:

--- a/stdio_msc_usb/msc_usb.c
+++ b/stdio_msc_usb/msc_usb.c
@@ -39,12 +39,11 @@ static bool msc_ejected = true;
 
 void stdio_msc_usb_do_msc(void)
 {
-	if (stdio_msc_usb_disable_stdio()) {
-		msc_ejected = false;
-		while (!msc_ejected)
-			tud_task();
-		stdio_msc_usb_enable_stdio();
-	}
+	stdio_msc_usb_disable_irq_tud_task();
+	msc_ejected = false;
+	while (!msc_ejected)
+		tud_task();
+	stdio_msc_usb_enable_irq_tud_task();
 }
 
 // Invoked when received SCSI_CMD_INQUIRY
@@ -203,19 +202,22 @@ int32_t tud_msc_scsi_cb (uint8_t lun, uint8_t const scsi_cmd[16],
 				(scsi_prevent_allow_medium_removal_t const *)
 				scsi_cmd;
 
-			if ((prevent_allow->prohibit_removal & 3) == 0)
-				resplen = 0;	// allow succeeds
-			else
-				resplen = -1;	// any prevents unsupported
+			resplen = 0;		// report success
 		}
 		break;
 
 	case SCSI_CMD_VERIFY_10:
-		resplen = 0;		// report success
+		if (msc_ejected)
+			resplen = -1;
+		else
+			resplen = 0;		// report success
 		break;
 
 	case SCSI_CMD_SYNCHRONIZE_CACHE_10:
-		resplen = 0;		// report success
+		if (msc_ejected)
+			resplen = -1;
+		else
+			resplen = 0;		// report success
 		break;
 
 	default:


### PR DESCRIPTION
Keeps stdio working to allow debugging printf's.

macOS doesn't send start/stop unload when prevent cmd fails.