### PR TITLE
add memory status display

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ set(Z80PACK ${CMAKE_SOURCE_DIR}/../z80pack)
 
 add_executable(${PROJECT_NAME}
 	picosim.c
+	button.c
 	dazzler.c
 	disks.c
 	lcd.c

--- a/button.c
+++ b/button.c
@@ -1,0 +1,54 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+#include "pico/stdlib.h"
+#include "pico/multicore.h"
+#include "hardware/sync.h"
+#include "hardware/structs/ioqspi.h"
+
+// Picoboard has a button attached to the flash CS pin, which the bootrom
+// checks, and jumps straight to the USB bootcode if the button is pressed
+// (pulling flash CS low). We can check this pin in by jumping to some code in
+// SRAM (so that the XIP interface is not required), floating the flash CS
+// pin, and observing whether it is pulled low.
+//
+// This doesn't work if others are trying to access flash at the same time,
+// e.g. XIP streamer, or the other core.
+
+int __no_inline_not_in_flash_func(get_bootsel_button)(void) {
+    const uint CS_PIN_INDEX = 1;
+
+    // Lock out the other core
+    multicore_lockout_start_blocking();
+
+    // Must disable interrupts, as interrupt handlers may be in flash, and we
+    // are about to temporarily disable flash access!
+    uint32_t flags = save_and_disable_interrupts();
+
+    // Set chip select to Hi-Z
+    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                    GPIO_OVERRIDE_LOW << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+    // Note we can't call into any sleep functions in flash right now
+    for (volatile int i = 0; i < 1000; ++i);
+
+    // The HI GPIO registers in SIO can observe and control the 6 QSPI pins.
+    // Note the button pulls the pin *low* when pressed.
+    bool button_state = !(sio_hw->gpio_hi_in & (1u << CS_PIN_INDEX));
+
+    // Need to restore the state of chip select, else we are going to have a
+    // bad time when we return to code in flash!
+    hw_write_masked(&ioqspi_hw->io[CS_PIN_INDEX].ctrl,
+                    GPIO_OVERRIDE_NORMAL << IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_LSB,
+                    IO_QSPI_GPIO_QSPI_SS_CTRL_OEOVER_BITS);
+
+    restore_interrupts(flags);
+
+    multicore_lockout_end_blocking();
+
+    return button_state;
+}

--- a/button.h
+++ b/button.h
@@ -1,0 +1,7 @@
+/**
+ * Copyright (c) 2020 Raspberry Pi (Trading) Ltd.
+ *
+ * SPDX-License-Identifier: BSD-3-Clause
+ */
+
+extern int get_bootsel_button(void);

--- a/dazzler.c
+++ b/dazzler.c
@@ -324,12 +324,12 @@ void dazzler_ctl_out(BYTE data)
 	if (data & 128) {
 		if (state == 0) {
 			state = 1;
-			lcd_set_draw_func(dazzler_draw);
+			lcd_custom_disp(dazzler_draw);
 		}
 	} else {
 		if (state == 1) {
 			state = 0;
-			lcd_default_draw_func();
+			lcd_status_disp();
 		}
 	}
 }

--- a/lcd.h
+++ b/lcd.h
@@ -10,10 +10,12 @@
 #include "LCD_1in14_V2.h"
 #include "GUI_Paint.h"
 
+typedef void (*lcd_func_t)(int first_flag);
+
 extern void lcd_init(void), lcd_exit(void);
 extern void lcd_set_rotated(int rotated);
-extern void lcd_set_draw_func(void (*draw_func)(int first_flag));
-extern void lcd_default_draw_func(void);
+extern void lcd_custom_disp(lcd_func_t draw_func);
+extern void lcd_status_disp(void);
 extern void lcd_brightness(int brightness);
 
 #endif /* !LCD_INC */

--- a/picosim.c
+++ b/picosim.c
@@ -108,13 +108,13 @@ int main(void)
 
 	/* when using USB UART wait until it is connected */
 #if LIB_PICO_STDIO_USB || (LIB_STDIO_MSC_USB && !STDIO_MSC_USB_DISABLE_STDIO)
-	lcd_set_draw_func(draw_wait_term);
+	lcd_custom_disp(draw_wait_term);
 	while (!tud_cdc_connected())
 		sleep_ms(100);
 #endif
 
 	/* print banner */
-	lcd_set_draw_func(draw_banner);
+	lcd_custom_disp(draw_banner);
 	printf("\fZ80pack release %s, %s\n", RELEASE, COPYR);
 	printf("%s release %s\n", USR_COM, USR_REL);
 	printf("%s\n\n", USR_CPR);
@@ -130,7 +130,7 @@ int main(void)
 
 	PC = 0xff00;		/* power on jump into the boot ROM */
 
-	lcd_default_draw_func(); /* tell LCD task to display default infos */
+	lcd_status_disp();	/* tell LCD task to display status */
 
 #ifdef WANT_ICE
 	ice_cmd_loop(0);


### PR DESCRIPTION
See how memory changes in real-time. Shows both memory banks.

Toggle current status display with boot select button!

Don't know if this is really useful. The button check is a bit crazy, it stops the other core, so that nothing accesses the flash memory. I do this 5 times a second.