### PR TITLE
fix rotated LCD, a little nicer banner, tidy-up p001_in

### DIFF
--- a/lcd/LCD/LCD_1in14_V2.c
+++ b/lcd/LCD/LCD_1in14_V2.c
@@ -205,8 +205,11 @@ void __not_in_flash_func(LCD_1IN14_V2_SetRotated)(uint8_t Rotated)
 		MemoryAccessReg = 0x70; /* MX=1, MV=1, ML=1 */
 	else
 		MemoryAccessReg = 0x00;
-	if (Rotated)
+	if (Rotated) {
 		MemoryAccessReg ^= 0xc0; /* MX=!MX, MY=!MY */
+		LCD_1IN14_V2.ROTATED = 1;
+	} else
+		LCD_1IN14_V2.ROTATED = 0;
 
 	/* Set the read / write scan direction of the frame memory */
 	LCD_1IN14_V2_SendCommand(0x36); /* Memory Data Access Control */
@@ -257,9 +260,9 @@ void __not_in_flash_func(LCD_1IN14_V2_SetWindows)(uint16_t Xstart,
 
 	if (LCD_1IN14_V2.SCAN_DIR == LCD_HORIZONTAL) {
 		x = 40;
-		y = 53;
+		y = LCD_1IN14_V2.ROTATED ? 52 : 53;
 	} else {
-		x = 52;
+		x = LCD_1IN14_V2.ROTATED ? 53 : 52;
 		y = 40;
 	}
 	/* set the X coordinates */

--- a/lcd/LCD/LCD_1in14_V2.h
+++ b/lcd/LCD/LCD_1in14_V2.h
@@ -41,6 +41,7 @@ typedef struct {
 	uint16_t WIDTH;
 	uint16_t HEIGHT;
 	uint8_t SCAN_DIR;
+	uint8_t ROTATED;
 } LCD_1IN14_V2_ATTRIBUTES;
 
 extern LCD_1IN14_V2_ATTRIBUTES LCD_1IN14_V2;

--- a/sim.h
+++ b/sim.h
@@ -25,7 +25,7 @@
 #define SBSIZE	4	/* number of software breakpoints */
 #endif
 
-#define USR_COM "Raspberry RP2040 Z80/8080 emulator"
+#define USR_COM "Waveshare RP2040-GEEK Z80/8080 emulator"
 #define USR_REL "1.2"
 #define USR_CPR "Copyright (C) 2024 by Udo Munk & Thomas Eberhardt"
 

--- a/simio.c
+++ b/simio.c
@@ -125,24 +125,23 @@ static BYTE p000_in(void)
  */
 static BYTE p001_in(void)
 {
-#if LIB_PICO_STDIO_UART && !(LIB_PICO_STDIO_USB || (LIB_STDIO_MSC_USB && !STDIO_MSC_USB_DISABLE_STDIO))
+	int input_avail = 0;
+
+#if LIB_PICO_STDIO_UART
 	uart_inst_t *my_uart = PICO_DEFAULT_UART_INSTANCE;
 
-	if (!uart_is_readable(my_uart))
+	if (uart_is_readable(my_uart))
+		input_avail = 1;
 #endif
-#if (LIB_PICO_STDIO_USB || (LIB_STDIO_MSC_USB && !STDIO_MSC_USB_DISABLE_STDIO)) && !LIB_PICO_STDIO_UART
-	if (!tud_cdc_available())
+#if LIB_PICO_STDIO_USB || (LIB_STDIO_MSC_USB && !STDIO_MSC_USB_DISABLE_STDIO)
+	if (tud_cdc_available())
+		input_avail = 1;
 #endif
-#if (LIB_PICO_STDIO_USB || (LIB_STDIO_MSC_USB && !STDIO_MSC_USB_DISABLE_STDIO)) && LIB_PICO_STDIO_UART
-	uart_inst_t *my_uart = PICO_DEFAULT_UART_INSTANCE;
 
-	if (!uart_is_readable(my_uart) && !tud_cdc_available())
-#endif
-		return sio_last;
-	else {
+	if (input_avail)
 		sio_last = getchar();
-		return sio_last;
-	}
+
+	return sio_last;
 }
 
 /*


### PR DESCRIPTION
It seems one must also adjust the memory access window for the rotation to work correctly. The rotated LCD was missing the top frame line (y = 0) of the memory pixmap display.
Also protect low level LCD library calls with the lcd_mutex.

Make the banner a little bit nicer (always perfectly centered).

Tidy-up p001_in, looked a bit wild.

Corrected USR_COM in sim.h.