### PR TITLE
initialize panel state, small includes cleanup, don't set random date

### DIFF
--- a/disks.c
+++ b/disks.c
@@ -23,8 +23,8 @@
 #include "simglb.h"
 #include "simmem.h"
 
-#include "f_util.h"
 #include "ff.h"
+#include "f_util.h"
 #include "hw_config.h"
 
 #include "sd-fdc.h"

--- a/disks.h
+++ b/disks.h
@@ -16,6 +16,8 @@
 #include "sim.h"
 #include "simdefs.h"
 
+#include "ff.h"
+
 #define NUMDISK	4	/* number of disk drives */
 #define DISKLEN	22	/* path length for disk drives /DISKS80/filename.DSK */
 

--- a/picosim.c
+++ b/picosim.c
@@ -28,7 +28,6 @@
 #include "pico/time.h"
 #include "hardware/adc.h"
 
-#include "ff.h"
 #include "hw_config.h"
 #include "rtc.h"
 
@@ -162,6 +161,11 @@ int main(void)
 	tmax = speed * 10000;	/* theoretically */
 
 	PC = 0xff00;		/* power on jump into the boot ROM */
+#ifdef SIMPLEPANEL
+	cpu_bus = CPU_WO | CPU_M1 | CPU_MEMR;
+	fp_led_address = PC;
+	fp_led_data = getmem(PC);
+#endif
 
 	lcd_status_disp();	/* tell LCD task to display status */
 

--- a/simcfg.c
+++ b/simcfg.c
@@ -23,7 +23,6 @@
 #include "pico/stdlib.h"
 #include "pico/time.h"
 
-#include "f_util.h"
 #include "ff.h"
 
 #include "sim.h"
@@ -92,7 +91,8 @@ void config(void)
 	unsigned int br;
 	int go_flag = 0, brightness = 90, rotated = 0;
 	int i, n, menu;
-	datetime_t t;
+	datetime_t t = { .year = 2024, .month = 6, .day = 13, .dotw = 4,
+			.hour = 20, .min = 27, .sec = 53 };
 	static const char *dotw[7] = { "Sun", "Mon", "Tue", "Wed",
 				       "Thu", "Fri", "Sat" };
 


### PR DESCRIPTION
Initialize the panel state, so you have the right initial LEDs when using the ICE.

Don't set the RTC to a random date/time when no config file is present. I choose the date of the initial commit of this project.