### PR TITLE
add reset_memory() to clear selected bank and use it in hwctl_out() reset

### DIFF
--- a/simio.c
+++ b/simio.c
@@ -215,6 +215,7 @@ static void hwctl_out(BYTE data)
 
 	if (data & 64) {
 		reset_cpu();		/* reset CPU */
+		reset_memory();		/* reset memory */
 		PC = 0xff00;		/* power on jump to boot ROM */
 		dazzler_ctl_out(0);	/* switch Dazzler off */
 		return;

--- a/simmem.c
+++ b/simmem.c
@@ -43,3 +43,8 @@ void init_memory(void)
 	for (i = 0; i < 0xc000; i++)
 		bnk1[i] = rand() % 256;
 }
+
+void reset_memory(void)
+{
+	selbnk = 0;
+}

--- a/simmem.h
+++ b/simmem.h
@@ -23,7 +23,7 @@
 extern BYTE bnk0[65536], bnk1[49152];
 extern BYTE selbnk;
 
-extern void init_memory(void);
+extern void init_memory(void), reset_memory(void);
 
 /* Last page in memory is ROM and write protected. Some software */
 /* expects a ROM in upper memory, if not it will wrap arround to */

--- a/stdio_msc_usb/stdio_msc_usb.c
+++ b/stdio_msc_usb/stdio_msc_usb.c
@@ -42,6 +42,8 @@ void stdio_msc_usb_enable_irq_tud_task(void) {
 
 void stdio_msc_usb_disable_irq_tud_task(void) {
     if (!mutex_try_enter_block_until(&stdio_msc_usb_mutex, make_timeout_time_ms(PICO_STDIO_DEADLOCK_TIMEOUT_MS))) {
+        // deadlocked, hope for the best
+        irq_tud_task_enabled = false;
         return;
     }
     irq_tud_task_enabled = false;


### PR DESCRIPTION
Also small addition to stdio_msc_usb for dead lock case.

This makes reset.com work.